### PR TITLE
Fix #91 - update gradle version to overcome build error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0-alpha3'
+        classpath 'com.android.tools.build:gradle:1.5.0'
     }
 }
 


### PR DESCRIPTION
Quick fix by android studio.
In accordance with what is suggested here:
http://stackoverflow.com/questions/29063968/plugin-is-too-old-please-update-to-a-more-recent-version-or-set-android-daily