### PR TITLE
fix message syntax to use  "habit.." vs "habits.."

### DIFF
--- a/app/src/main/java/org/isoron/uhabits/commands/DeleteHabitsCommand.java
+++ b/app/src/main/java/org/isoron/uhabits/commands/DeleteHabitsCommand.java
@@ -52,7 +52,7 @@ public class DeleteHabitsCommand extends Command
 
     public Integer getExecuteStringId()
     {
-        if ((this.plural) && (toast_habits_deleted != null)) {
+        if (this.plural) {
             return R.string.toast_habits_deleted;
         }
         else {
@@ -62,7 +62,7 @@ public class DeleteHabitsCommand extends Command
 
     public Integer getUndoStringId()
     {
-        if ((this.plural) && (toast_habits_deleted != null)){
+        if (this.plural){
             return R.string.toast_habits_restored;
         }
         else {

--- a/app/src/main/java/org/isoron/uhabits/commands/DeleteHabitsCommand.java
+++ b/app/src/main/java/org/isoron/uhabits/commands/DeleteHabitsCommand.java
@@ -27,12 +27,12 @@ import java.util.List;
 public class DeleteHabitsCommand extends Command
 {
     private List<Habit> habits;
-    private Boolean plural;
+    private Boolean hasOnlyOne;
 
     public DeleteHabitsCommand(List<Habit> habits)
     {
         this.habits = habits;
-        this.plural = (habits.size() > 1) ? true : false;
+        this.hasOnlyOne = (habits.size() == 1) ? true : false;
     }
 
     @Override
@@ -52,21 +52,21 @@ public class DeleteHabitsCommand extends Command
 
     public Integer getExecuteStringId()
     {
-        if (this.plural) {
-            return R.string.toast_habits_deleted;
+        if (this.hasOnlyOne) {
+            return R.string.toast_habit_deleted;
         }
         else {
-            return R.string.toast_habit_deleted;
+            return R.string.toast_habits_deleted;
         }
     }
 
     public Integer getUndoStringId()
     {
-        if (this.plural){
-            return R.string.toast_habits_restored;
+        if (this.hasOnlyOne){
+            return R.string.toast_habit_restored;
         }
         else {
-            return R.string.toast_habit_restored;
+            return R.string.toast_habits_restored;
         }
     }
 }

--- a/app/src/main/java/org/isoron/uhabits/commands/DeleteHabitsCommand.java
+++ b/app/src/main/java/org/isoron/uhabits/commands/DeleteHabitsCommand.java
@@ -52,7 +52,7 @@ public class DeleteHabitsCommand extends Command
 
     public Integer getExecuteStringId()
     {
-        if (this.plural) {
+        if ((this.plural) && (toast_habits_deleted != null)) {
             return R.string.toast_habits_deleted;
         }
         else {
@@ -62,7 +62,7 @@ public class DeleteHabitsCommand extends Command
 
     public Integer getUndoStringId()
     {
-        if (this.plural) {
+        if ((this.plural) && (toast_habits_deleted != null)){
             return R.string.toast_habits_restored;
         }
         else {

--- a/app/src/main/java/org/isoron/uhabits/commands/DeleteHabitsCommand.java
+++ b/app/src/main/java/org/isoron/uhabits/commands/DeleteHabitsCommand.java
@@ -32,7 +32,7 @@ public class DeleteHabitsCommand extends Command
     public DeleteHabitsCommand(List<Habit> habits)
     {
         this.habits = habits;
-        this.plural = (habits.size > 1) ? true : false;
+        this.plural = (habits.size() > 1) ? true : false;
     }
 
     @Override

--- a/app/src/main/java/org/isoron/uhabits/commands/DeleteHabitsCommand.java
+++ b/app/src/main/java/org/isoron/uhabits/commands/DeleteHabitsCommand.java
@@ -27,10 +27,12 @@ import java.util.List;
 public class DeleteHabitsCommand extends Command
 {
     private List<Habit> habits;
+    private Boolean plural;
 
     public DeleteHabitsCommand(List<Habit> habits)
     {
         this.habits = habits;
+        this.plural = habits.size > 1;
     }
 
     @Override
@@ -50,11 +52,21 @@ public class DeleteHabitsCommand extends Command
 
     public Integer getExecuteStringId()
     {
-        return R.string.toast_habit_deleted;
+        if (this.plural) {
+            return R.string.toast_habits_deleted;
+        }
+        else {
+            return R.string.toast_habit_deleted;
+        }
     }
 
     public Integer getUndoStringId()
     {
-        return R.string.toast_habit_restored;
+        if (this.plural) {
+            return R.string.toast_habits_restored;
+        }
+        else {
+            return R.string.toast_habit_restored;
+        }
     }
 }

--- a/app/src/main/java/org/isoron/uhabits/commands/DeleteHabitsCommand.java
+++ b/app/src/main/java/org/isoron/uhabits/commands/DeleteHabitsCommand.java
@@ -32,7 +32,7 @@ public class DeleteHabitsCommand extends Command
     public DeleteHabitsCommand(List<Habit> habits)
     {
         this.habits = habits;
-        this.plural = habits.size > 1;
+        this.plural = (habits.size > 1) ? true : false;
     }
 
     @Override

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -13,6 +13,8 @@
 <string name="color_picker_default_title">"غير اللون"</string>
 <string name="toast_habit_created">"تم صنع عادة "</string>
 <string name="toast_habit_deleted">"تم حذف عادة "</string>
+<string name="toast_habits_deleted">"تم حذف عادة "</string>
+<string name="toast_habits_restored">"تم  ترجيع عادة"</string>
 <string name="toast_habit_restored">"تم  ترجيع عادة"</string>
 <string name="toast_nothing_to_undo">"لا شيء للتراجع"</string>
 <string name="toast_nothing_to_redo">"لا شيء لتكرار"</string>
@@ -21,7 +23,9 @@
 <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
 <string name="toast_habit_changed_back">"تم ترجيع العادة إلى أصلها"</string>
 <string name="toast_habit_archived">"تم أرشيف العادات"</string>
+<string name="toast_habits_archived">"تم أرشيف العادات"</string>
 <string name="toast_habit_unarchived">"تم إزالة العادة من الأرشيف "</string>
+<string name="toast_habits_unarchived">"تم إزالة العادة من الأرشيف "</string>
 <string name="overview">"نظرة عامة"</string>
 <string name="habit_strength">"قوة العادة"</string>
 <string name="history">"التاريخ"</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -11,7 +11,9 @@
 <string name="color_picker_default_title">"Canviar color"</string>
 <string name="toast_habit_created">"Hàbit creat."</string>
 <string name="toast_habit_deleted">"Hàbits esborrats."</string>
+<string name="toast_habits_deleted">"Hàbits esborrats."</string>
 <string name="toast_habit_restored">"Hàbits restaurats."</string>
+<string name="toast_habits_restored">"Hàbits restaurats."</string>
 <string name="toast_nothing_to_undo">"Res a desfer."</string>
 <string name="toast_nothing_to_redo">"Res a refer."</string>
 <string name="toast_habit_changed">"Hàbit modificat."</string>
@@ -19,7 +21,9 @@
 <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
 <string name="toast_habit_changed_back">"Hàbit restaurat."</string>
 <string name="toast_habit_archived">"Hàbits arxivats."</string>
+<string name="toast_habits_archived">"Hàbits arxivats."</string>
 <string name="toast_habit_unarchived">"Hàbits trets de l'arxiu."</string>
+<string name="toast_habits_unarchived">"Hàbits trets de l'arxiu."</string>
 <string name="overview">"Visió general"</string>
 <string name="habit_strength">"Fortalesa de l'hàbit"</string>
 <string name="history">"Història"</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -13,7 +13,9 @@
 <string name="color_picker_default_title">"Změnit barvu"</string>
 <string name="toast_habit_created">"Zvyk vytvořen."</string>
 <string name="toast_habit_deleted">"Zvyky smazány."</string>
+<string name="toast_habits_deleted">"Zvyky smazány."</string>
 <string name="toast_habit_restored">"Zvyky obnoveny."</string>
+<string name="toast_habits_restored">"Zvyky obnoveny."</string>
 <string name="toast_nothing_to_undo">"Nelze jít zpět."</string>
 <string name="toast_nothing_to_redo">"Nelze jít vpřed."</string>
 <string name="toast_habit_changed">"Zvyk změněn."</string>
@@ -21,7 +23,9 @@
 <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
 <string name="toast_habit_changed_back">"Zvyk změněn zpět."</string>
 <string name="toast_habit_archived">"Archivováno."</string>
+<string name="toast_habits_archived">"Archivováno."</string>
 <string name="toast_habit_unarchived">"Zvyky obnoveny."</string>
+<string name="toast_habits_unarchived">"Zvyky obnoveny."</string>
 <string name="overview">"Přehled"</string>
 <string name="habit_strength">"Síla zvyku"</string>
 <string name="history">"Historie"</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -10,16 +10,20 @@
 <string name="add_habit">"Gewohnheit hinzufügen"</string>
 <string name="color_picker_default_title">"Farbe ändern"</string>
 <string name="toast_habit_created">"Gewohnheit erstellt."</string>
-<string name="toast_habit_deleted">"Gewohnheiten gelöscht."</string>
-<string name="toast_habit_restored">"Gewohnheiten wiederhergestellt."</string>
+<string name="toast_habit_deleted">"Gewohnheit gelöscht."</string>
+<string name="toast_habits_deleted">"Gewohnheiten gelöscht."</string>
+<string name="toast_habit_restored">"Gewohnheit wiederhergestellt."</string>
+<string name="toast_habits_restored">"Gewohnheiten wiederhergestellt."</string>
 <string name="toast_nothing_to_undo">"Nichts zum rückgängig machen."</string>
 <string name="toast_nothing_to_redo">"Nichts zum wiederherstellen."</string>
 <string name="toast_habit_changed">"Gewohnheit geändert."</string>
 
 <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
 <string name="toast_habit_changed_back">"Gewohnheit zurückgeändert."</string>
-<string name="toast_habit_archived">"Gewohnheiten archiviert."</string>
-<string name="toast_habit_unarchived">"Gewohnheiten dearchiviert."</string>
+<string name="toast_habit_archived">"Gewohnheit archiviert."</string>
+<string name="toast_habits_archived">"Gewohnheiten archiviert."</string>
+<string name="toast_habit_unarchived">"Gewohnheit dearchiviert."</string>
+<string name="toast_habits_unarchived">"Gewohnheiten dearchiviert."</string>
 <string name="overview">"Übersicht"</string>
 
 <!-- Fuzzy -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -186,7 +186,6 @@ Los recordatorios se pueden marcar, aplazar o descartar directamente desde tu re
 <string name="year">"Año"</string>
 
 <!-- Middle part of the sentence '1 time in xx days' -->
-<!-- Middle part of the sentence '1 time in xx days' -->
 <string name="time_every">"veces en"</string>
 <string name="every_x_days">"Cada %d días"</string>
 <string name="every_x_weeks">"Cada %d semanas"</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -10,15 +10,18 @@
 <string name="add_habit">"Agregar hábito"</string>
 <string name="color_picker_default_title">"Cambiar color"</string>
 <string name="toast_habit_created">"Hábito creado."</string>
-<string name="toast_habit_deleted">"Hábitos eliminados."</string>
-<string name="toast_habit_restored">"Hábitos restaurados."</string>
+<string name="toast_habit_deleted">"Hábito eliminado."</string>
+<string name="toast_habits_deleted">"Hábitos eliminados."</string>
+<string name="toast_habit_restored">"Hábito restaurado."</string>
+<string name="toast_habits_restored">"Hábitos restaurados."</string>
 <string name="toast_nothing_to_undo">"Nada que deshacer."</string>
 <string name="toast_nothing_to_redo">"Nada que rehacer."</string>
 <string name="toast_habit_changed">"Hábito cambiado."</string>
 
 <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
 <string name="toast_habit_changed_back">"Hábito cambiado devuelta."</string>
-<string name="toast_habit_archived">"Hábitos archivados."</string>
+<string name="toast_habit_archived">"Hábito archivado."</string>
+<string name="toast_habits_archived">"Hábitos archivados."</string>
 <string name="toast_habit_unarchived">"Hábitos desarchivados."</string>
 <string name="overview">"Visión general"</string>
 <string name="habit_strength">"Fuerza del hábito"</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -11,7 +11,9 @@
 <string name="color_picker_default_title">"Changer la couleur"</string>
 <string name="toast_habit_created">"Habitude créée."</string>
 <string name="toast_habit_deleted">"Habitude supprimée."</string>
+<string name="toast_habits_deleted">"Habitude supprimée."</string>
 <string name="toast_habit_restored">"Habitude rétablie."</string>
+<string name="toast_habits_restored">"Habitude rétablie."</string>
 <string name="toast_nothing_to_undo">"Rien à annuler."</string>
 <string name="toast_nothing_to_redo">"Rien à refaire."</string>
 <string name="toast_habit_changed">"Habitude changée."</string>
@@ -19,7 +21,9 @@
 <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
 <string name="toast_habit_changed_back">"Habitude restaurée."</string>
 <string name="toast_habit_archived">"Habitudes archivées."</string>
+<string name="toast_habits_archived">"Habitudes archivées."</string>
 <string name="toast_habit_unarchived">"Habitudes désarchivées."</string>
+<string name="toast_habits_unarchived">"Habitudes désarchivées."</string>
 <string name="overview">"Vue d'ensemble"</string>
 <string name="habit_strength">"Force de l'habitude"</string>
 <string name="history">"Historique"</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -11,7 +11,9 @@
     <string name="color_picker_default_title">"Promijeni boju"</string>
     <string name="toast_habit_created">"Navika je stvorena."</string>
     <string name="toast_habit_deleted">"Navike su obrisane."</string>
+    <string name="toast_habits_deleted">"Navike su obrisane."</string>
     <string name="toast_habit_restored">"Navike su obnovljene."</string>
+    <string name="toast_habits_restored">"Navike su obnovljene."</string>
     <string name="toast_nothing_to_undo">"Nema ništa za poništavanje."</string>
     <string name="toast_nothing_to_redo">"Nema ništa za obnavljanje."</string>
     <string name="toast_habit_changed">"Navika je promijenjena."</string>
@@ -19,7 +21,9 @@
     <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
     <string name="toast_habit_changed_back">"Navika je vraćena u početno stanje."</string>
     <string name="toast_habit_archived">"Navike su arhivirane."</string>
+    <string name="toast_habits_archived">"Navike su arhivirane."</string>
     <string name="toast_habit_unarchived">"Navike su vraćene iz arhive."</string>
+    <string name="toast_habits_unarchived">"Navike su vraćene iz arhive."</string>
     <string name="overview">"Pregled"</string>
     <string name="habit_strength">"Jačina navike"</string>
     <string name="history">"Povijest"</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -11,7 +11,9 @@
 <string name="color_picker_default_title">"Ganti warna"</string>
 <string name="toast_habit_created">"Kebiasaan ditambahkan."</string>
 <string name="toast_habit_deleted">"Kebiasaan dihapus."</string>
+<string name="toast_habits_deleted">"Kebiasaan dihapus."</string>
 <string name="toast_habit_restored">"Kebiasaan dikembalikan."</string>
+<string name="toast_habits_restored">"Kebiasaan dikembalikan."</string>
 <string name="toast_nothing_to_undo">"Tidak ada aksi sebelumnya."</string>
 <string name="toast_nothing_to_redo">"Tidak ada aksi sesudahnya."</string>
 <string name="toast_habit_changed">"Kebiasaan diubah."</string>
@@ -19,7 +21,9 @@
 <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
 <string name="toast_habit_changed_back">"Kebiasaan telah dikembalikan."</string>
 <string name="toast_habit_archived">"Kebiasaan diarsipkan."</string>
+<string name="toast_habits_archived">"Kebiasaan diarsipkan."</string>
 <string name="toast_habit_unarchived">"Kebiasaan dikeluarkan dari arsip."</string>
+<string name="toast_habits_unarchived">"Kebiasaan dikeluarkan dari arsip."</string>
 <string name="overview">"Keseluruhan"</string>
 <string name="habit_strength">"Kekuatan Kebiasaan"</string>
 <string name="history">"Riwayat"</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -13,7 +13,9 @@
 <string name="color_picker_default_title">"Cambia colore"</string>
 <string name="toast_habit_created">"Abitudine creata."</string>
 <string name="toast_habit_deleted">"Abitudine rimossa."</string>
+<string name="toast_habits_deleted">"Abitudine rimossa."</string>
 <string name="toast_habit_restored">"Abitudine ripristinata."</string>
+<string name="toast_habits_restored">"Abitudine ripristinata."</string>
 <string name="toast_nothing_to_undo">"Niente da annullare."</string>
 <string name="toast_nothing_to_redo">"Niente da ripetere."</string>
 <string name="toast_habit_changed">"Abitudine modificata."</string>
@@ -21,7 +23,9 @@
 <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
 <string name="toast_habit_changed_back">"Abitudine ripristinata."</string>
 <string name="toast_habit_archived">"Abitudine archiviata."</string>
+<string name="toast_habits_archived">"Abitudine archiviata."</string>
 <string name="toast_habit_unarchived">"Abitudine ripristinata."</string>
+<string name="toast_habits_unarchived">"Abitudine ripristinata."</string>
 <string name="overview">"Panoramica"</string>
 <string name="habit_strength">"Forza dell'abitudine"</string>
 <string name="history">"Cronologia"</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -11,7 +11,9 @@
 <string name="color_picker_default_title">"色の変更"</string>
 <string name="toast_habit_created">"習慣を作成しました。"</string>
 <string name="toast_habit_deleted">"習慣を削除しました。"</string>
+<string name="toast_habits_deleted">"習慣を削除しました。"</string>
 <string name="toast_habit_restored">"習慣を復元しました。"</string>
+<string name="toast_habits_restored">"習慣を復元しました。"</string>
 <string name="toast_nothing_to_undo">"元に戻すことはできません。"</string>
 <string name="toast_nothing_to_redo">"繰り返しはできません。"</string>
 <string name="toast_habit_changed">"習慣を変更しました。"</string>
@@ -19,7 +21,9 @@
 <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
 <string name="toast_habit_changed_back">"習慣を元に戻しました。"</string>
 <string name="toast_habit_archived">"習慣をアーカイブしました。"</string>
+<string name="toast_habits_archived">"習慣をアーカイブしました。"</string>
 <string name="toast_habit_unarchived">"習慣のアーカイブを戻しました。"</string>
+<string name="toast_habits_unarchived">"習慣のアーカイブを戻しました。"</string>
 <string name="overview">"概要"</string>
 <string name="habit_strength">"習慣の強さ"</string>
 <string name="history">"履歴"</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -11,7 +11,9 @@
 <string name="color_picker_default_title">"색상 정하기"</string>
 <string name="toast_habit_created">"습관을 시작합니다."</string>
 <string name="toast_habit_deleted">"습관을 지웠습니다."</string>
+<string name="toast_habits_deleted">"습관을 지웠습니다."</string>
 <string name="toast_habit_restored">"습관을 복원합니다."</string>
+<string name="toast_habits_restored">"습관을 복원합니다."</string>
 <string name="toast_nothing_to_undo">"복원할 것이 없습니다."</string>
 <string name="toast_nothing_to_redo">"복원할 것이 없습니다."</string>
 <string name="toast_habit_changed">"습관을 수정했습니다."</string>
@@ -19,7 +21,9 @@
 <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
 <string name="toast_habit_changed_back">"습관을 복원했습니다."</string>
 <string name="toast_habit_archived">"습관을 보관합니다."</string>
+<string name="toast_habits_archived">"습관을 보관합니다."</string>
 <string name="toast_habit_unarchived">"습관을 제거합니다."</string>
+<string name="toast_habits_unarchived">"습관을 제거합니다."</string>
 <string name="overview">"홈"</string>
 <string name="habit_strength">"습관 완성정도"</string>
 <string name="history">"기록"</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -11,7 +11,9 @@
 <string name="color_picker_default_title">"Zmień kolor"</string>
 <string name="toast_habit_created">"Utworzono nawyk."</string>
 <string name="toast_habit_deleted">"Usunięto nawyki."</string>
+<string name="toast_habits_deleted">"Usunięto nawyki."</string>
 <string name="toast_habit_restored">"Przywrócono nawyki."</string>
+<string name="toast_habits_restored">"Przywrócono nawyki."</string>
 <string name="toast_nothing_to_undo">"Nic do cofnięcia."</string>
 <string name="toast_nothing_to_redo">"Nic do powtórzenia"</string>
 <string name="toast_habit_changed">"Zmieniono nawyk."</string>
@@ -19,7 +21,9 @@
 <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
 <string name="toast_habit_changed_back">"Zmieniono nawyk z powrotem."</string>
 <string name="toast_habit_archived">"Nawyki zarchiwizowane."</string>
+<string name="toast_habits_archived">"Nawyki zarchiwizowane."</string>
 <string name="toast_habit_unarchived">"Nawyki odarchiwizowane."</string>
+<string name="toast_habits_unarchived">"Nawyki odarchiwizowane."</string>
 <string name="overview">"Przegląd"</string>
 <string name="habit_strength">"Siła nawyku"</string>
 <string name="history">"Historia"</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -11,7 +11,9 @@
 <string name="color_picker_default_title">"Mudar cor"</string>
 <string name="toast_habit_created">"Hábito criado."</string>
 <string name="toast_habit_deleted">"Hábito deletado."</string>
+<string name="toast_habits_deleted">"Hábito deletado."</string>
 <string name="toast_habit_restored">"Hábitos restaurados."</string>
+<string name="toast_habits_restored">"Hábitos restaurados."</string>
 <string name="toast_nothing_to_undo">"Nada para desfazer."</string>
 <string name="toast_nothing_to_redo">"Nada para refazer."</string>
 <string name="toast_habit_changed">"Hábito modificado."</string>
@@ -19,7 +21,9 @@
 <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
 <string name="toast_habit_changed_back">"Hábito restaurado."</string>
 <string name="toast_habit_archived">"Hábitos arquivados."</string>
+<string name="toast_habits_archived">"Hábitos arquivados."</string>
 <string name="toast_habit_unarchived">"Hábitos restaurados."</string>
+<string name="toast_habits_unarchived">"Hábitos restaurados."</string>
 <string name="overview">"Visão geral"</string>
 <string name="habit_strength">"Estabilidade"</string>
 <string name="history">"Histórico"</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -11,7 +11,9 @@
 <string name="color_picker_default_title">"Изменить цвет"</string>
 <string name="toast_habit_created">"Привычка создана."</string>
 <string name="toast_habit_deleted">"Привычки удалены."</string>
+<string name="toast_habits_deleted">"Привычки удалены."</string>
 <string name="toast_habit_restored">"Привычки восстановлены."</string>
+<string name="toast_habits_restored">"Привычки восстановлены."</string>
 <string name="toast_nothing_to_undo">"Отменять нечего."</string>
 <string name="toast_nothing_to_redo">"Повторять нечего."</string>
 <string name="toast_habit_changed">"Привычка изменена."</string>
@@ -19,7 +21,9 @@
 <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
 <string name="toast_habit_changed_back">"Изменения привычки отменены."</string>
 <string name="toast_habit_archived">"Привычки архивированы."</string>
+<string name="toast_habits_archived">"Привычки архивированы."</string>
 <string name="toast_habit_unarchived">"Привычки возвращены из архива."</string>
+<string name="toast_habits_unarchived">"Привычки возвращены из архива."</string>
 <string name="overview">"Обзор"</string>
 <string name="habit_strength">"Сила привычки"</string>
 <string name="history">"История"</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -11,7 +11,9 @@
     <string name="color_picker_default_title">"Spremeni barvo"</string>
     <string name="toast_habit_created">"Navada ustvarjana."</string>
     <string name="toast_habit_deleted">"Navada izbrisana."</string>
+    <string name="toast_habits_deleted">"Navada izbrisana."</string>
     <string name="toast_habit_restored">"Navada obnovljena."</string>
+    <string name="toast_habits_restored">"Navada obnovljena."</string>
     <string name="toast_nothing_to_undo">"Nič za razveljaviti."</string>
     <string name="toast_nothing_to_redo">"Nič za ponovno opraviti."</string>
     <string name="toast_habit_changed">"Navada spremenjena."</string>
@@ -19,7 +21,9 @@
     <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
     <string name="toast_habit_changed_back">"Navada obnovljena."</string>
     <string name="toast_habit_archived">"Navada arhivirana."</string>
+    <string name="toast_habits_archived">"Navada arhivirana."</string>
     <string name="toast_habit_unarchived">"Navada dearhivirana."</string>
+    <string name="toast_habits_unarchived">"Navada dearhivirana."</string>
     <string name="overview">"Pregled"</string>
     <string name="habit_strength">"Moč navade"</string>
     <string name="history">"Zgodovina"</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -11,7 +11,9 @@
     <string name="color_picker_default_title">"Промена боје"</string>
     <string name="toast_habit_created">"Навика је створена."</string>
     <string name="toast_habit_deleted">"Навике су обрисане."</string>
+    <string name="toast_habits_deleted">"Навике су обрисане."</string>
     <string name="toast_habit_restored">"Навике су враћене."</string>
+    <string name="toast_habits_restored">"Навике су враћене."</string>
     <string name="toast_nothing_to_undo">"Нема шта да се опозове."</string>
     <string name="toast_nothing_to_redo">"Нема шта да се понови."</string>
     <string name="toast_habit_changed">"Навика је промењена."</string>
@@ -19,7 +21,9 @@
     <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
     <string name="toast_habit_changed_back">"Навика је враћена."</string>
     <string name="toast_habit_archived">"Навике су архивиране."</string>
+    <string name="toast_habits_archived">"Навике су архивиране."</string>
     <string name="toast_habit_unarchived">"Навике су враћене из архива."</string>
+    <string name="toast_habits_unarchived">"Навике су враћене из архива."</string>
     <string name="overview">"Преглед"</string>
     <string name="habit_strength">"Снага навике"</string>
     <string name="history">"Историја"</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -11,7 +11,9 @@
 <string name="color_picker_default_title">"Byt färg"</string>
 <string name="toast_habit_created">"Vana skapad"</string>
 <string name="toast_habit_deleted">"Vana borttagen"</string>
+<string name="toast_habits_deleted">"Vana borttagen"</string>
 <string name="toast_habit_restored">"Vana återställd"</string>
+<string name="toast_habits_restored">"Vana återställd"</string>
 <string name="toast_nothing_to_undo">"Inget att ångra"</string>
 <string name="toast_nothing_to_redo">"Inget att göra om"</string>
 <string name="toast_habit_changed">"Vana ändrad"</string>
@@ -19,7 +21,9 @@
 <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
 <string name="toast_habit_changed_back">"Vana ändrad tillbaka"</string>
 <string name="toast_habit_archived">"Vanor arkiverade"</string>
+<string name="toast_habits_archived">"Vanor arkiverade"</string>
 <string name="toast_habit_unarchived">"Vanor avakriverade"</string>
+<string name="toast_habits_unarchived">"Vanor avakriverade"</string>
 <string name="overview">"Översikt"</string>
 <string name="habit_strength">"Vanestyrka"</string>
 <string name="history">"Historik"</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -11,7 +11,9 @@
 <string name="color_picker_default_title">"Renk Değiştir"</string>
 <string name="toast_habit_created">"Alışkanlık oluşturuldu."</string>
 <string name="toast_habit_deleted">"Alışkanlık silindi."</string>
+<string name="toast_habits_deleted">"Alışkanlık silindi."</string>
 <string name="toast_habit_restored">"Alışkanlık"</string>
+<string name="toast_habits_restored">"Alışkanlık"</string>
 <string name="toast_nothing_to_undo">"Geri alınacak birşey yok."</string>
 <string name="toast_nothing_to_redo">"Tekrar yapılacak birşey yok."</string>
 <string name="toast_habit_changed">"Alışkanlık değişti."</string>
@@ -19,7 +21,9 @@
 <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
 <string name="toast_habit_changed_back">"Alışkanlık eski haline getirildi."</string>
 <string name="toast_habit_archived">"Alışkanlık arşivlendi."</string>
+<string name="toast_habits_archived">"Alışkanlık arşivlendi."</string>
 <string name="toast_habit_unarchived">"Alışkanlık arşivden çıkarıldı."</string>
+<string name="toast_habits_unarchived">"Alışkanlık arşivden çıkarıldı."</string>
 <string name="overview">"Genel bakış"</string>
 <string name="habit_strength">"Alışkanlık dayanımı"</string>
 <string name="history">"Geçmiş"</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -11,7 +11,9 @@
 <string name="color_picker_default_title">"Змінити колір"</string>
 <string name="toast_habit_created">"Звичка створена."</string>
 <string name="toast_habit_deleted">"Звички видалені."</string>
+<string name="toast_habits_deleted">"Звички видалені."</string>
 <string name="toast_habit_restored">"Звички відновлені."</string>
+<string name="toast_habits_restored">"Звички відновлені."</string>
 <string name="toast_nothing_to_undo">"Відміняти нічого."</string>
 <string name="toast_nothing_to_redo">"Повторювати нічого."</string>
 <string name="toast_habit_changed">"Звичка змінена."</string>
@@ -19,7 +21,9 @@
 <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
 <string name="toast_habit_changed_back">"Зміна звички скасована."</string>
 <string name="toast_habit_archived">"Звички архівовані."</string>
+<string name="toast_habits_archived">"Звички архівовані."</string>
 <string name="toast_habit_unarchived">"Звички повернуті з архіву."</string>
+<string name="toast_habits_unarchived">"Звички повернуті з архіву."</string>
 <string name="overview">"Огляд"</string>
 <string name="habit_strength">"Сила звички"</string>
 <string name="history">"Історія"</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -11,7 +11,9 @@
 <string name="color_picker_default_title">"选择颜色"</string>
 <string name="toast_habit_created">"习惯已创建"</string>
 <string name="toast_habit_deleted">"习惯已删除"</string>
+<string name="toast_habits_deleted">"习惯已删除"</string>
 <string name="toast_habit_restored">"习惯已恢复"</string>
+<string name="toast_habits_restored">"习惯已恢复"</string>
 <string name="toast_nothing_to_undo">"没有可以撤销的习惯."</string>
 <string name="toast_nothing_to_redo">"没有可以恢复的习惯."</string>
 <string name="toast_habit_changed">"习惯已被修改."</string>
@@ -19,7 +21,9 @@
 <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
 <string name="toast_habit_changed_back">"修改已取消."</string>
 <string name="toast_habit_archived">"习惯存档成功."</string>
+<string name="toast_habits_archived">"习惯存档成功."</string>
 <string name="toast_habit_unarchived">"存档已取消."</string>
+<string name="toast_habits_unarchived">"存档已取消."</string>
 <string name="overview">"总览"</string>
 <string name="habit_strength">"习惯强度"</string>
 <string name="history">"历史"</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -11,7 +11,9 @@
 <string name="color_picker_default_title">"選擇顏色"</string>
 <string name="toast_habit_created">"已創建的習慣"</string>
 <string name="toast_habit_deleted">"刪除習慣"</string>
+<string name="toast_habits_deleted">"刪除習慣"</string>
 <string name="toast_habit_restored">"恢復習慣"</string>
+<string name="toast_habits_restored">"恢復習慣"</string>
 <string name="toast_nothing_to_undo">"沒有可以撤銷的習慣"</string>
 <string name="toast_nothing_to_redo">"沒有可以恢復的習慣"</string>
 <string name="toast_habit_changed">"習慣已經被修改"</string>
@@ -19,7 +21,9 @@
 <!-- This appears when the user edits a habit, and then undoes the action. The habit is "changed back" to what is was before. Alternatively, "Habit restored". -->
 <string name="toast_habit_changed_back">"修改已取消"</string>
 <string name="toast_habit_archived">"習慣存檔成功"</string>
+<string name="toast_habits_archived">"習慣存檔成功"</string>
 <string name="toast_habit_unarchived">"未完成"</string>
+<string name="toast_habits_unarchived">"未完成"</string>
 <string name="overview">"總覽"</string>
 <string name="habit_strength">"強度"</string>
 <string name="history">"歴史紀錄"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,14 +31,18 @@
     <string name="color_picker_default_title">Change color</string>
 
     <string name="toast_habit_created">Habit created.</string>
-    <string name="toast_habit_deleted">Habits deleted.</string>
-    <string name="toast_habit_restored">Habits restored.</string>
+    <string name="toast_habit_deleted">Habit deleted.</string>
+    <string name="toast_habits_deleted">Habits deleted.</string>
+    <string name="toast_habit_restored">Habit restored.</string>
+    <string name="toast_habits_restored">Habits restored.</string>
     <string name="toast_nothing_to_undo">Nothing to undo.</string>
     <string name="toast_nothing_to_redo">Nothing to redo.</string>
     <string name="toast_habit_changed">Habit changed.</string>
     <string name="toast_habit_changed_back">Habit changed back.</string>
-    <string name="toast_habit_archived">Habits archived.</string>
-    <string name="toast_habit_unarchived">Habits unarchived.</string>
+    <string name="toast_habit_archived">Habit archived.</string>
+    <string name="toast_habits_archived">Habits archived.</string>
+    <string name="toast_habit_unarchived">Habit unarchived.</string>
+    <string name="toast_habits_unarchived">Habits unarchived.</string>
 
     <string name="title_activity_show_habit" translatable="false"/>
     <string name="overview">Overview</string>


### PR DESCRIPTION
In english the app incorrectly stated "habits deleted" or "habits restored"
even when it was only 1 "habit". 
Now app correctly uses singular form of "habit" when appropriate:
 "habit deleted" or "habit restored"

new strings were created for stating "habits.."
toast_habits_deleted
toast_habits_restored
toast_habits_archived

previous strings were altered to state "habit.."
toast_habit_deleted
toast_habit_restored
toast_habit_archived

DeleteHabitsCommand.java
returns the appropriate message for:
"habit(s) deleted"
"habit(s) restored"

TODO: do the same for "habit(s) archived"
- once code is modified to allow multiple habits to be archived at once.

Fix #131