### PR TITLE
relative size of the marks in the frequency view

### DIFF
--- a/app/src/main/java/org/isoron/uhabits/activities/common/views/FrequencyChart.java
+++ b/app/src/main/java/org/isoron/uhabits/activities/common/views/FrequencyChart.java
@@ -66,6 +66,7 @@ public class FrequencyChart extends ScrollableChart
 
     @NonNull
     private HashMap<Long, Integer[]> frequency;
+    private int maxFreq;
 
     public FrequencyChart(Context context)
     {
@@ -90,7 +91,21 @@ public class FrequencyChart extends ScrollableChart
     public void setFrequency(HashMap<Long, Integer[]> frequency)
     {
         this.frequency = frequency;
+        maxFreq = getMaxFreq(frequency);
         postInvalidate();
+    }
+
+    private int getMaxFreq(HashMap<Long, Integer[]> frequency)
+    {
+        int maxValue = 1;
+        for (Integer[] values : frequency.values())
+        {
+            for (Integer value : values)
+            {
+                maxValue = Math.max(value, maxValue);
+            }
+        }
+        return maxValue;
     }
 
     public void setIsBackgroundTransparent(boolean isBackgroundTransparent)
@@ -237,8 +252,8 @@ public class FrequencyChart extends ScrollableChart
         float padding = rect.height() * 0.2f;
         // maximal allowed mark radius
         float maxRadius = (rect.height() - 2 * padding) / 2.0f;
-        // the real mark radius is scaled down by a factor depending on the value
-        float scale = Math.min(value, 4) / 4.0f;
+        // the real mark radius is scaled down by a factor depending on the maximal frequency
+        float scale = 1.0f/maxFreq * value;
         float radius = maxRadius * scale;
 
         int colorIndex = Math.round((colors.length-1) * scale);

--- a/app/src/main/java/org/isoron/uhabits/activities/common/views/FrequencyChart.java
+++ b/app/src/main/java/org/isoron/uhabits/activities/common/views/FrequencyChart.java
@@ -235,10 +235,14 @@ public class FrequencyChart extends ScrollableChart
     private void drawMarker(Canvas canvas, RectF rect, Integer value)
     {
         float padding = rect.height() * 0.2f;
-        float radius =
-            (rect.height() - 2 * padding) / 2.0f / 4.0f * Math.min(value, 4);
+        // maximal allowed mark radius
+        float maxRadius = (rect.height() - 2 * padding) / 2.0f;
+        // the real mark radius is scaled down by a factor depending on the value
+        float scale = Math.min(value, 4) / 4.0f;
+        float radius = maxRadius * scale;
 
-        pGraph.setColor(colors[Math.min(3, Math.max(0, value - 1))]);
+        int colorIndex = Math.round((colors.length-1) * scale);
+        pGraph.setColor(colors[colorIndex]);
         canvas.drawCircle(rect.centerX(), rect.centerY(), radius, pGraph);
     }
 

--- a/app/src/main/java/org/isoron/uhabits/models/RepetitionList.java
+++ b/app/src/main/java/org/isoron/uhabits/models/RepetitionList.java
@@ -130,7 +130,7 @@ public abstract class RepetitionList
         for (Repetition r : reps)
         {
             Calendar date = DateUtils.getCalendar(r.getTimestamp());
-            int weekday = date.get(Calendar.DAY_OF_WEEK) % 7;
+            int weekday = DateUtils.getWeekday(r.getTimestamp());
             date.set(Calendar.DAY_OF_MONTH, 1);
 
             long timestamp = date.getTimeInMillis();

--- a/app/src/main/java/org/isoron/uhabits/utils/DateUtils.java
+++ b/app/src/main/java/org/isoron/uhabits/utils/DateUtils.java
@@ -206,7 +206,7 @@ public abstract class DateUtils
     public static int getWeekday(long timestamp)
     {
         GregorianCalendar day = getCalendar(timestamp);
-        return day.get(DAY_OF_WEEK) % 7;
+        return javaWeekdayToLoopWeekday(day.get(DAY_OF_WEEK));
     }
 
     /**


### PR DESCRIPTION
In this PR I'll like to introduce relative size of the marks based on the maximum frequency.

I have a low frequency habit that I mark once a month. Consequently, in the frequency view, for the whole month I have only one small gray dot at some weekday even though the actual desired frequency was achived (looks sort of depressive :). The reason was that the mark size will become large only if I do it every week and reach the value >=4.
Of course it does not work for low-frequency habits...