### PR TITLE
Increase width of name column according to screen size

### DIFF
--- a/app/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsRootView.java
+++ b/app/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsRootView.java
@@ -166,7 +166,7 @@ public class ListHabitsRootView extends BaseRootView
     private int getCheckmarkCount()
     {
         Resources res = getResources();
-        float labelWidth = res.getDimension(R.dimen.habitNameWidth);
+        float labelWidth = Math.max(getMeasuredWidth() / 3, res.getDimension(R.dimen.habitNameWidth));
         float buttonWidth = res.getDimension(R.dimen.checkmarkWidth);
         return Math.min(MAX_CHECKMARK_COUNT, Math.max(0,
             (int) ((getMeasuredWidth() - labelWidth) / buttonWidth)));


### PR DESCRIPTION
This is regarding the issue: https://github.com/iSoron/uhabits/issues/62

I changed `labelWidth` calculation to take into account screen's width. Now it's either 1/3 screen width OR R.dimen.habitNameWidth depending on which is larger. 