### PR TITLE
Use of Cyrillic letters to display Bulgarian

### DIFF
--- a/app/src/main/res/layout/about.xml
+++ b/app/src/main/res/layout/about.xml
@@ -140,7 +140,7 @@
 
                 <TextView
                     style="@style/About.Item"
-                    android:text="Mihail Stefanov (Bǎlgarski)"/>
+                    android:text="Mihail Stefanov (Български)"/>
 
                 <TextView
                     style="@style/About.Item"


### PR DESCRIPTION
I switched the phonetic notation with Cyrillic letters to denote the Bulgarian language. I hope this is the proper place to offer this amendment.