### PR TITLE
Added stacked notifications (#243)

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/notifications/AndroidNotificationTray.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/notifications/AndroidNotificationTray.kt
@@ -46,8 +46,6 @@ class AndroidNotificationTray
 
     private val generalLoopNotificationGroup = "generalLoopHabitsNotificationGroup"
 
-    private var summaryShown = false
-
     override fun removeNotification(id: Int)
     {
         NotificationManagerCompat.from(context).cancel(id)
@@ -60,14 +58,9 @@ class AndroidNotificationTray
     {
         val notificationManager = NotificationManagerCompat.from(context)
 
-        if(! summaryShown)
-        {
-            val summary = buildSummary(reminderTime)
+        val summary = buildSummary(reminderTime)
 
-            notificationManager.notify(Int.MAX_VALUE, summary)
-
-            summaryShown = true
-        }
+        notificationManager.notify(Int.MAX_VALUE, summary)
 
         val notification = buildNotification(habit, reminderTime, timestamp)
 

--- a/uhabits-android/src/main/java/org/isoron/uhabits/notifications/AndroidNotificationTray.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/notifications/AndroidNotificationTray.kt
@@ -44,9 +44,9 @@ class AndroidNotificationTray
 
 ) : NotificationTray.SystemTray {
 
-    val generalLoopNotificationGroup = "generalLoopHabitsNotificationGroup"
+    private val generalLoopNotificationGroup = "generalLoopHabitsNotificationGroup"
 
-    var summaryShown = false
+    private var summaryShown = false
 
     override fun removeNotification(id: Int)
     {


### PR DESCRIPTION
Added bundled/grouped/stacked notifications as per #243.

The summary ID needs to be unique, not used by other notifications, any other guaranteed unique id generating method is fine as well.