### PR TITLE
Make notifications also blink the LED

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/notifications/AndroidNotificationTray.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/notifications/AndroidNotificationTray.kt
@@ -22,6 +22,7 @@ package org.isoron.uhabits.notifications
 import android.app.*
 import android.content.*
 import android.graphics.BitmapFactory.*
+import android.graphics.Color
 import android.support.v4.app.*
 import android.support.v4.app.NotificationCompat.*
 import org.isoron.androidbase.*
@@ -84,6 +85,7 @@ class AndroidNotificationTray
                 .setWhen(reminderTime)
                 .setShowWhen(true)
                 .setOngoing(preferences.shouldMakeNotificationsSticky())
+                .setLights(Color.RED, 1000, 1000)
                 .build()
 
         val notificationManager = context.getSystemService(

--- a/uhabits-android/src/main/java/org/isoron/uhabits/notifications/AndroidNotificationTray.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/notifications/AndroidNotificationTray.kt
@@ -72,7 +72,7 @@ class AndroidNotificationTray
                 .addAction(checkAction)
                 .addAction(snoozeAction)
 
-        val notification = NotificationCompat.Builder(context)
+        val builder = NotificationCompat.Builder(context)
                 .setSmallIcon(R.drawable.ic_notification)
                 .setContentTitle(habit.name)
                 .setContentText(habit.description)
@@ -85,8 +85,9 @@ class AndroidNotificationTray
                 .setWhen(reminderTime)
                 .setShowWhen(true)
                 .setOngoing(preferences.shouldMakeNotificationsSticky())
-                .setLights(Color.RED, 1000, 1000)
-                .build()
+        if (preferences.shouldMakeNotificationsLed())
+                builder.setLights(Color.RED, 1000, 1000)
+        val notification = builder.build()
 
         val notificationManager = context.getSystemService(
                 Activity.NOTIFICATION_SERVICE) as NotificationManager

--- a/uhabits-android/src/main/java/org/isoron/uhabits/preferences/SharedPreferencesStorage.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/preferences/SharedPreferencesStorage.kt
@@ -85,6 +85,8 @@ class SharedPreferencesStorage
                 preferences.isCheckmarkSequenceReversed = getBoolean(key, false)
             "pref_sticky_notifications" ->
                 preferences.setNotificationsSticky(getBoolean(key, false))
+            "pref_led_notifications" ->
+                preferences.setNotificationsLed(getBoolean(key, false))
             "pref_feature_sync" ->
                 preferences.isSyncEnabled = getBoolean(key, false)
         }

--- a/uhabits-android/src/main/res/values/strings.xml
+++ b/uhabits-android/src/main/res/values/strings.xml
@@ -188,6 +188,8 @@
 
     <string name="sticky_notifications">Make notifications sticky</string>
     <string name="sticky_notifications_description">Prevents notifications from being swiped away.</string>
+    <string name="led_notifications">LED</string>
+    <string name="led_notifications_description">Notifications blinking light.</string>
     <string name="repair_database">Repair database</string>
     <string name="database_repaired">Database repaired.</string>
 

--- a/uhabits-android/src/main/res/xml/preferences.xml
+++ b/uhabits-android/src/main/res/xml/preferences.xml
@@ -68,6 +68,12 @@
             android:title="@string/sticky_notifications"
             android:summary="@string/sticky_notifications_description"/>
 
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="pref_led_notifications"
+            android:title="@string/led_notifications"
+            android:summary="@string/led_notifications_description"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/uhabits-core/src/main/java/org/isoron/uhabits/core/preferences/Preferences.java
+++ b/uhabits-core/src/main/java/org/isoron/uhabits/core/preferences/Preferences.java
@@ -263,6 +263,12 @@ public class Preferences
         for (Listener l : listeners) l.onNotificationsChanged();
     }
 
+    public void setNotificationsLed(boolean enabled)
+    {
+        storage.putBoolean("pref_led_notifications", enabled);
+        for (Listener l : listeners) l.onNotificationsChanged();
+    }
+
     public void setCheckmarkSequenceReversed(boolean reverse)
     {
         shouldReverseCheckmarks = reverse;
@@ -279,6 +285,11 @@ public class Preferences
     public boolean shouldMakeNotificationsSticky()
     {
         return storage.getBoolean("pref_sticky_notifications", false);
+    }
+
+    public boolean shouldMakeNotificationsLed()
+    {
+        return storage.getBoolean("pref_led_notifications", false);
     }
 
     public boolean isCheckmarkSequenceReversed()

--- a/uhabits-core/src/test/java/org/isoron/uhabits/core/preferences/PreferencesTest.java
+++ b/uhabits-core/src/test/java/org/isoron/uhabits/core/preferences/PreferencesTest.java
@@ -159,6 +159,10 @@ public class PreferencesTest extends BaseUnitTest
         prefs.setNotificationsSticky(true);
         assertTrue(prefs.shouldMakeNotificationsSticky());
 
+        assertFalse(prefs.shouldMakeNotificationsLed());
+        prefs.setNotificationsLed(true);
+        assertTrue(prefs.shouldMakeNotificationsLed());
+
         assertThat(prefs.getSnoozeInterval(), equalTo(15L));
         prefs.setSnoozeInterval(30);
         assertThat(prefs.getSnoozeInterval(), equalTo(30L));


### PR DESCRIPTION
These two commits implement LED blinking for notifications, similarly to how e.g. calendar apps do it. I've split it into two commits, as I don't know if this is worth having a configuration option (the second commit may be dropped for all I care).
