### PR TITLE
fix snooze button in notifications

### DIFF
--- a/uhabits-core/src/main/java/org/isoron/uhabits/core/preferences/Preferences.java
+++ b/uhabits-core/src/main/java/org/isoron/uhabits/core/preferences/Preferences.java
@@ -142,7 +142,7 @@ public class Preferences
 
     public long getSnoozeInterval()
     {
-        return storage.getLong("pref_snooze_interval", 15L);
+        return Long.parseLong(storage.getString("pref_snooze_interval", "15"));
     }
 
     public String getSyncAddress()
@@ -313,7 +313,7 @@ public class Preferences
 
     public void setSnoozeInterval(int interval)
     {
-        storage.putLong("pref_snooze_interval", interval);
+        storage.putString("pref_snooze_interval", String.valueOf(interval));
     }
 
     public void setNumericalHabitsFeatureEnabled(boolean enabled)


### PR DESCRIPTION
The "pref_snooze_interval" preference is manipulated by the ListPreference
class, which according to its docs stores the preference as a string.
Without reverting this part of 864636705d2f43dd54d0045f01d40fb2d65be7cd,
this results in "java.lang.ClassCastException: java.lang.String cannot be
cast to java.lang.Long" when trying to snooze a notification.