### PR TITLE
Allow user to duplicate / clone habits #295

### DIFF
--- a/android-base/src/main/java/org/isoron/androidbase/activities/BaseSelectionMenu.java
+++ b/android-base/src/main/java/org/isoron/androidbase/activities/BaseSelectionMenu.java
@@ -40,6 +40,8 @@ public abstract class BaseSelectionMenu
     @Nullable
     private ActionMode actionMode;
 
+    public static boolean duplicateIsSelected = false;
+
     /**
      * Finishes the selection operation.
      */

--- a/uhabits-android/src/main/java/org/isoron/uhabits/HabitsApplicationComponent.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/HabitsApplicationComponent.java
@@ -54,6 +54,8 @@ public interface HabitsApplicationComponent
 
     CreateHabitCommandFactory getCreateHabitCommandFactory();
 
+    DuplicateHabitCommandFactory getDuplicateHabitCommandFactory();
+
     EditHabitCommandFactory getEditHabitCommandFactory();
 
     GenericImporter getGenericImporter();

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/edit/EditHabitDialog.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/edit/EditHabitDialog.java
@@ -40,6 +40,7 @@ import org.isoron.uhabits.core.preferences.*;
 import butterknife.*;
 
 import static android.view.View.GONE;
+import static org.isoron.androidbase.activities.BaseSelectionMenu.duplicateIsSelected;
 import static org.isoron.uhabits.core.ui.ThemeSwitcher.THEME_LIGHT;
 
 public class EditHabitDialog extends AppCompatDialogFragment
@@ -119,23 +120,29 @@ public class EditHabitDialog extends AppCompatDialogFragment
 
     protected int getTitle()
     {
-        if (originalHabit != null) return R.string.edit_habit;
+        if (originalHabit != null) {
+            if(duplicateIsSelected){
+                return R.string.duplicate_habit;
+            }else{
+            return R.string.edit_habit;}
+        }
         else return R.string.create_habit;
     }
 
     protected void saveHabit(@NonNull Habit habit)
     {
         if (originalHabit == null)
-        {
             commandRunner.execute(component
-                .getCreateHabitCommandFactory()
-                .create(habitList, habit), null);
-        }
+                    .getCreateHabitCommandFactory()
+                    .create(habitList, habit), null);
         else
-        {
+            if (duplicateIsSelected){
+                commandRunner.execute(component
+                        .getDuplicateHabitCommandFactory()
+                        .create(habitList, habit), null);
+            }else {
             commandRunner.execute(component.getEditHabitCommandFactory().
-                create(habitList, originalHabit, habit), originalHabit.getId());
-        }
+                    create(habitList, originalHabit, habit), originalHabit.getId());}
     }
 
     private int getTypeFromArguments()

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsScreen.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsScreen.kt
@@ -230,6 +230,7 @@ class ListHabitsScreen
             is ChangeHabitColorCommand -> return R.string.toast_habit_changed
             is CreateHabitCommand -> return R.string.toast_habit_created
             is DeleteHabitsCommand -> return R.string.toast_habit_deleted
+            is DuplicateHabitCommand -> return R.string.toast_habit_duplicated
             is EditHabitCommand -> return R.string.toast_habit_changed
             is UnarchiveHabitsCommand -> return R.string.toast_habit_unarchived
             else -> return null

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsSelectionMenu.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsSelectionMenu.kt
@@ -64,6 +64,12 @@ class ListHabitsSelectionMenu @Inject constructor(
                 return true
             }
 
+            R.id.action_duplicate -> {
+                duplicateIsSelected = true
+                behavior.onDuplicateHabits()
+                return true
+            }
+
             R.id.action_color -> {
                 behavior.onChangeColor()
                 return true

--- a/uhabits-android/src/main/res/menu/list_habits_selection.xml
+++ b/uhabits-android/src/main/res/menu/list_habits_selection.xml
@@ -46,4 +46,9 @@
         android:title="@string/delete"
         app:showAsAction="never"/>
 
+    <item
+        android:id="@+id/action_duplicate"
+        android:title="@string/duplicate"
+        app:showAsAction="never"/>
+
 </menu>

--- a/uhabits-android/src/main/res/values/strings.xml
+++ b/uhabits-android/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="app_name">Loop Habit Tracker</string>
     <string name="main_activity_title">Habits</string>
     <string name="action_settings">Settings</string>
+    <string name="duplicate">Duplicate</string>
     <string name="edit">Edit</string>
     <string name="delete">Delete</string>
     <string name="archive">Archive</string>
@@ -31,6 +32,7 @@
 
     <string name="toast_habit_created">Habit created</string>
     <string name="toast_habit_deleted">Habit deleted</string>
+    <string name="toast_habit_duplicated">Habit duplicated</string>
     <string name="toast_habit_restored">Habits restored</string>
     <string name="toast_nothing_to_undo">Nothing to undo</string>
     <string name="toast_nothing_to_redo">Nothing to redo</string>
@@ -60,6 +62,7 @@
     <string name="validation_at_most_one_rep_per_day">You can have at most one repetition per day</string>
     <string name="create_habit">Create habit</string>
     <string name="edit_habit">Edit habit</string>
+    <string name="duplicate_habit">Duplicate habit</string>
     <string name="check">Check</string>
     <string name="snooze">Later</string>
 
@@ -100,6 +103,7 @@
     <string name="hint_drag">To rearrange the entries, press-and-hold on the name of the habit, then drag it to the correct place.</string>
     <string name="hint_landscape">You can see more days by putting your phone in landscape mode.</string>
     <string name="delete_habit">Delete Habit</string>
+    <string name="delete_habits">Delete Habits</string>
     <string name="delete_habits_message">The habit will be permanently deleted. This action cannot be undone.</string>
     <string name="habit_not_found">Habit deleted / not found</string>
     <string name="weekends">Weekends</string>

--- a/uhabits-android/src/main/res/values/strings.xml
+++ b/uhabits-android/src/main/res/values/strings.xml
@@ -30,7 +30,7 @@
     <string name="color_picker_default_title">Change color</string>
 
     <string name="toast_habit_created">Habit created</string>
-    <string name="toast_habit_deleted">Habits deleted</string>
+    <string name="toast_habit_deleted">Habit deleted</string>
     <string name="toast_habit_restored">Habits restored</string>
     <string name="toast_nothing_to_undo">Nothing to undo</string>
     <string name="toast_nothing_to_redo">Nothing to redo</string>
@@ -99,8 +99,8 @@
     <string name="hint_title">Did you know?</string>
     <string name="hint_drag">To rearrange the entries, press-and-hold on the name of the habit, then drag it to the correct place.</string>
     <string name="hint_landscape">You can see more days by putting your phone in landscape mode.</string>
-    <string name="delete_habits">Delete Habits</string>
-    <string name="delete_habits_message">The habits will be permanently deleted. This action cannot be undone.</string>
+    <string name="delete_habit">Delete Habit</string>
+    <string name="delete_habits_message">The habit will be permanently deleted. This action cannot be undone.</string>
     <string name="habit_not_found">Habit deleted / not found</string>
     <string name="weekends">Weekends</string>
     <string name="any_weekday">Monday to Friday</string>

--- a/uhabits-core/src/main/java/org/isoron/uhabits/core/commands/DuplicateHabitCommand.java
+++ b/uhabits-core/src/main/java/org/isoron/uhabits/core/commands/DuplicateHabitCommand.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2016 Álinson Santos Xavier <isoron@gmail.com>
+ *
+ * This file is part of Loop Habit Tracker.
+ *
+ * Loop Habit Tracker is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * Loop Habit Tracker is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.isoron.uhabits.core.commands;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
+
+import org.isoron.uhabits.core.models.Habit;
+import org.isoron.uhabits.core.models.HabitList;
+import org.isoron.uhabits.core.models.HabitNotFoundException;
+import org.isoron.uhabits.core.models.ModelFactory;
+
+/**
+ * Command to create a habit.
+ */
+@AutoFactory
+public class DuplicateHabitCommand extends Command
+{
+    ModelFactory modelFactory;
+
+    HabitList habitList;
+
+    @NonNull
+    Habit model;
+
+    @Nullable
+    Long savedId;
+
+    public DuplicateHabitCommand(@Provided @NonNull ModelFactory modelFactory,
+                                 @NonNull HabitList habitList,
+                                 @NonNull Habit model)
+    {
+        this.modelFactory = modelFactory;
+        this.habitList = habitList;
+        this.model = model;
+    }
+
+    @Override
+    public void execute()
+    {
+        Habit savedHabit = modelFactory.buildHabit();
+        savedHabit.copyFrom(model);
+        savedHabit.setId(savedId);
+
+        habitList.add(savedHabit);
+        savedId = savedHabit.getId();
+    }
+
+    @NonNull
+    @Override
+    public Record toRecord()
+    {
+        return new Record(this);
+    }
+
+    @Override
+    public void undo()
+    {
+        if (savedId == null) throw new IllegalStateException();
+
+        Habit habit = habitList.getById(savedId);
+        if (habit == null) throw new HabitNotFoundException();
+
+        habitList.remove(habit);
+    }
+
+    public static class Record
+    {
+        @NonNull
+        public String id;
+
+        @NonNull
+        public String event = "CreateHabit";
+
+        @NonNull
+        public Habit.HabitData habit;
+
+        @Nullable
+        public Long savedId;
+
+        public Record(DuplicateHabitCommand command)
+        {
+            id = command.getId();
+            habit = command.model.getData();
+            savedId = command.savedId;
+        }
+
+        public DuplicateHabitCommand toCommand(@NonNull ModelFactory modelFactory,
+                                               @NonNull HabitList habitList)
+        {
+            Habit h = modelFactory.buildHabit(habit);
+
+            DuplicateHabitCommand command;
+            command = new DuplicateHabitCommand(modelFactory, habitList, h);
+            command.savedId = savedId;
+            command.setId(id);
+            return command;
+        }
+    }
+}

--- a/uhabits-core/src/main/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsSelectionMenuBehavior.java
+++ b/uhabits-core/src/main/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsSelectionMenuBehavior.java
@@ -109,6 +109,11 @@ public class ListHabitsSelectionMenuBehavior
         });
     }
 
+    public void onDuplicateHabits()
+    {
+        screen.showEditHabitsScreen(adapter.getSelected());
+    }
+
     public void onEditHabits()
     {
         screen.showEditHabitsScreen(adapter.getSelected());


### PR DESCRIPTION
This commit should add the feature to duplicate a habit. Doing so brings up the edit/create/duplicate screen allowing the user to make subtle changes to the duplicated habit.

It may need to be updated again as to unselect the original habit. Additionally if you select multiple it only duplicates the first selected. I figure thats probably a good thing since it could get complicated or messy with mass duplicating. Lastly the progress history does not duplicate which I assume makes sense but perhaps users want that duplicated?

Also a last note is I noticed my first commit is also contained into this pull request. Unsure how to remove it but all it does is change some "habits" to "habit", when deleting a habit. Pretty minor, does no damage nor benefit.