### PR TITLE
Custom reminder snooze delay

### DIFF
--- a/android-pickers/src/main/java/com/android/datetimepicker/time/TimePickerDialog.java
+++ b/android-pickers/src/main/java/com/android/datetimepicker/time/TimePickerDialog.java
@@ -63,6 +63,7 @@ public class TimePickerDialog extends AppCompatDialogFragment implements OnValue
     private static final int PULSE_ANIMATOR_DELAY = 300;
 
     private OnTimeSetListener mCallback;
+    private DialogInterface.OnDismissListener dismissListener;
 
     private HapticFeedbackController mHapticFeedbackController;
 
@@ -997,5 +998,16 @@ public class TimePickerDialog extends AppCompatDialogFragment implements OnValue
             }
             return false;
         }
+    }
+
+    public void setDismissListener( DialogInterface.OnDismissListener listener ) {
+        dismissListener = listener;
+    }
+
+    @Override
+    public void onDismiss(DialogInterface dialog) {
+        super.onDismiss(dialog);
+        if( dismissListener != null )
+            dismissListener.onDismiss(dialog);
     }
 }

--- a/uhabits-android/src/main/AndroidManifest.xml
+++ b/uhabits-android/src/main/AndroidManifest.xml
@@ -91,7 +91,11 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activities.habits.list.ListHabitsActivity"/>
         </activity>
-        <activity android:name=".notifications.SnoozeDelayActivity"></activity>
+        <activity android:name=".notifications.SnoozeDelayActivity"
+            android:excludeFromRecents="true"
+            android:launchMode="singleInstance"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar">
+        </activity>
 
         <receiver
             android:name=".widgets.CheckmarkWidgetProvider"

--- a/uhabits-android/src/main/AndroidManifest.xml
+++ b/uhabits-android/src/main/AndroidManifest.xml
@@ -91,6 +91,7 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activities.habits.list.ListHabitsActivity"/>
         </activity>
+        <activity android:name=".notifications.SnoozeDelayActivity"></activity>
 
         <receiver
             android:name=".widgets.CheckmarkWidgetProvider"

--- a/uhabits-android/src/main/java/org/isoron/uhabits/notifications/SnoozeDelayActivity.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/notifications/SnoozeDelayActivity.java
@@ -4,6 +4,7 @@ import android.app.*;
 import android.content.*;
 import android.os.*;
 import android.support.v4.app.*;
+import android.support.v7.view.*;
 import android.text.format.*;
 import android.util.*;
 
@@ -50,7 +51,10 @@ public class SnoozeDelayActivity extends FragmentActivity implements
 
     private void AskSnooze()
     {
-        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        HabitsApplicationComponent component = ((HabitsApplication) getApplicationContext()).getComponent();
+        int theme = component.getPreferences().getTheme() == THEME_DARK
+                ? R.style.Theme_AppCompat_Dialog_Alert : R.style.Theme_AppCompat_Light_Dialog_Alert;
+        AlertDialog.Builder builder = new AlertDialog.Builder(new ContextThemeWrapper(this, theme));
         builder.setTitle(R.string.select_snooze_delay)
                 .setItems(R.array.snooze_interval_names_reminder, this);
         AlertDialog dialog = builder.create();

--- a/uhabits-android/src/main/java/org/isoron/uhabits/notifications/SnoozeDelayActivity.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/notifications/SnoozeDelayActivity.java
@@ -1,0 +1,85 @@
+package org.isoron.uhabits.notifications;
+
+import android.content.*;
+import android.os.*;
+import android.support.v4.app.*;
+import android.text.format.*;
+import android.util.*;
+
+import com.android.datetimepicker.time.*;
+
+import org.isoron.uhabits.core.utils.DateUtils;
+import org.isoron.uhabits.receivers.*;
+
+import java.util.*;
+
+import static org.isoron.uhabits.core.utils.DateUtils.applyTimezone;
+
+public class SnoozeDelayActivity extends FragmentActivity implements
+        TimePickerDialog.OnTimeSetListener {
+
+    public static final String ACTION_ASK_SNOOZE = "org.isoron.uhabits.ACTION_ASK_SNOOZE";
+
+    private static final String TAG = "SnoozeDelayActivity";
+
+    @Override
+    protected void onCreate(Bundle bundle)
+    {
+        super.onCreate(bundle);
+        Intent intent = getIntent();
+        try
+        {
+            switch (intent.getAction())
+            {
+                case ACTION_ASK_SNOOZE:
+                    AskSnooze();
+                    break;
+            }
+        }
+        catch (RuntimeException e)
+        {
+            Log.e(TAG, "could not process intent", e);
+        }
+    }
+
+    private void AskSnooze()
+    {
+        final Calendar calendar = Calendar.getInstance();
+        int hour = calendar.get(Calendar.HOUR_OF_DAY);
+        int minute = calendar.get(Calendar.MINUTE);
+        TimePickerDialog dialog;
+        dialog = TimePickerDialog.newInstance(this,
+                hour, minute, DateFormat.is24HourFormat(this));
+        dialog.show(getSupportFragmentManager(),"timePicker");
+    }
+
+    @Override
+    public void onTimeSet(RadialPickerLayout view, int hourOfDay, int minute)
+    {
+        Calendar calendar = DateUtils.getStartOfTodayCalendar();
+        calendar.set(Calendar.HOUR_OF_DAY, hourOfDay);
+        calendar.set(Calendar.MINUTE, minute);
+        calendar.set(Calendar.SECOND, 0);
+        Long time = calendar.getTimeInMillis();
+        if (DateUtils.getLocalTime() > time)
+            time += DateUtils.DAY_LENGTH;
+        time = applyTimezone(time);
+
+        Intent intent = new Intent( ReminderReceiver.ACTION_SNOOZE_REMINDER_SET, getIntent().getData(),
+                this, ReminderReceiver.class );
+        intent.putExtra("reminderTime", time);
+        sendBroadcast(intent);
+
+        finish();
+    }
+
+    @Override
+    public void onTimeCleared(RadialPickerLayout view)
+    {
+        Intent intent = new Intent( ReminderReceiver.ACTION_DISMISS_REMINDER, getIntent().getData(),
+                this, ReminderReceiver.class );
+        sendBroadcast(intent);
+
+        finish();
+    }
+}

--- a/uhabits-android/src/main/java/org/isoron/uhabits/notifications/SnoozeDelayActivity.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/notifications/SnoozeDelayActivity.java
@@ -18,7 +18,7 @@ import static org.isoron.uhabits.core.ui.ThemeSwitcher.THEME_DARK;
 import static org.isoron.uhabits.core.utils.DateUtils.applyTimezone;
 
 public class SnoozeDelayActivity extends FragmentActivity implements
-        TimePickerDialog.OnTimeSetListener {
+        TimePickerDialog.OnTimeSetListener, DialogInterface.OnDismissListener {
 
     public static final String ACTION_ASK_SNOOZE = "org.isoron.uhabits.ACTION_ASK_SNOOZE";
 
@@ -54,6 +54,7 @@ public class SnoozeDelayActivity extends FragmentActivity implements
                 hour, minute, DateFormat.is24HourFormat(this));
         HabitsApplicationComponent component = ((HabitsApplication) getApplicationContext()).getComponent();
         dialog.setThemeDark(component.getPreferences().getTheme() == THEME_DARK);
+        dialog.setDismissListener(this);
         dialog.show(getSupportFragmentManager(),"timePicker");
     }
 
@@ -73,8 +74,6 @@ public class SnoozeDelayActivity extends FragmentActivity implements
                 this, ReminderReceiver.class );
         intent.putExtra("reminderTime", time);
         sendBroadcast(intent);
-
-        finish();
     }
 
     @Override
@@ -83,7 +82,11 @@ public class SnoozeDelayActivity extends FragmentActivity implements
         Intent intent = new Intent( ReminderReceiver.ACTION_DISMISS_REMINDER, getIntent().getData(),
                 this, ReminderReceiver.class );
         sendBroadcast(intent);
+    }
 
+    @Override
+    public void onDismiss(DialogInterface dialogInterface)
+    {
         finish();
     }
 }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/notifications/SnoozeDelayActivity.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/notifications/SnoozeDelayActivity.java
@@ -8,11 +8,13 @@ import android.util.*;
 
 import com.android.datetimepicker.time.*;
 
+import org.isoron.uhabits.*;
 import org.isoron.uhabits.core.utils.DateUtils;
 import org.isoron.uhabits.receivers.*;
 
 import java.util.*;
 
+import static org.isoron.uhabits.core.ui.ThemeSwitcher.THEME_DARK;
 import static org.isoron.uhabits.core.utils.DateUtils.applyTimezone;
 
 public class SnoozeDelayActivity extends FragmentActivity implements
@@ -50,6 +52,8 @@ public class SnoozeDelayActivity extends FragmentActivity implements
         TimePickerDialog dialog;
         dialog = TimePickerDialog.newInstance(this,
                 hour, minute, DateFormat.is24HourFormat(this));
+        HabitsApplicationComponent component = ((HabitsApplication) getApplicationContext()).getComponent();
+        dialog.setThemeDark(component.getPreferences().getTheme() == THEME_DARK);
         dialog.show(getSupportFragmentManager(),"timePicker");
     }
 

--- a/uhabits-android/src/main/java/org/isoron/uhabits/receivers/ReminderReceiver.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/receivers/ReminderReceiver.java
@@ -49,6 +49,9 @@ public class ReminderReceiver extends BroadcastReceiver
     public static final String ACTION_SNOOZE_REMINDER_SET =
             "org.isoron.uhabits.ACTION_SNOOZE_REMINDER_SET";
 
+    public static final String ACTION_SNOOZE_REMINDER_DELAY =
+            "org.isoron.uhabits.ACTION_SNOOZE_REMINDER_DELAY";
+
     private static final String TAG = "ReminderReceiver";
 
     @Override
@@ -99,6 +102,12 @@ public class ReminderReceiver extends BroadcastReceiver
                 case ACTION_SNOOZE_REMINDER_SET:
                     if (habit == null) return;
                     reminderController.snoozeNotificationSetReminderTime(habit, reminderTime);
+                    break;
+
+                case ACTION_SNOOZE_REMINDER_DELAY:
+                    if (habit == null) return;
+                    long snoozeDelay = intent.getIntExtra("snoozeDelay", 0);
+                    reminderController.snoozeNotificationAddDelay(habit, snoozeDelay);
                     break;
 
                 case Intent.ACTION_BOOT_COMPLETED:

--- a/uhabits-android/src/main/java/org/isoron/uhabits/receivers/ReminderReceiver.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/receivers/ReminderReceiver.java
@@ -46,6 +46,9 @@ public class ReminderReceiver extends BroadcastReceiver
     public static final String ACTION_SNOOZE_REMINDER =
         "org.isoron.uhabits.ACTION_SNOOZE_REMINDER";
 
+    public static final String ACTION_SNOOZE_REMINDER_SET =
+            "org.isoron.uhabits.ACTION_SNOOZE_REMINDER_SET";
+
     private static final String TAG = "ReminderReceiver";
 
     @Override
@@ -90,7 +93,12 @@ public class ReminderReceiver extends BroadcastReceiver
 
                 case ACTION_SNOOZE_REMINDER:
                     if (habit == null) return;
-                    reminderController.onSnooze(habit);
+                    reminderController.onSnooze(habit,context);
+                    break;
+
+                case ACTION_SNOOZE_REMINDER_SET:
+                    if (habit == null) return;
+                    reminderController.snoozeNotificationSetReminderTime(habit, reminderTime);
                     break;
 
                 case Intent.ACTION_BOOT_COMPLETED:

--- a/uhabits-android/src/main/res/values/constants.xml
+++ b/uhabits-android/src/main/res/values/constants.xml
@@ -49,6 +49,28 @@
         <item>-1</item>
     </string-array>
 
+    <string-array name="snooze_interval_names_reminder">
+        <item>@string/interval_15_minutes</item>
+        <item>@string/interval_30_minutes</item>
+        <item>@string/interval_1_hour</item>
+        <item>@string/interval_2_hour</item>
+        <item>@string/interval_4_hour</item>
+        <item>@string/interval_8_hour</item>
+        <item>@string/interval_24_hour</item>
+        <item>@string/interval_custom</item>
+    </string-array>
+
+    <integer-array name="snooze_interval_values_reminder" translatable="false">
+        <item>15</item>
+        <item>30</item>
+        <item>60</item>
+        <item>120</item>
+        <item>240</item>
+        <item>480</item>
+        <item>1440</item>
+        <item>-1</item>
+    </integer-array>
+
     <string-array name="frequencyQuickSelect" translatable="false">
         <item>@string/every_day</item>
         <item>@string/every_week</item>

--- a/uhabits-android/src/main/res/values/constants.xml
+++ b/uhabits-android/src/main/res/values/constants.xml
@@ -35,6 +35,7 @@
         <item>@string/interval_4_hour</item>
         <item>@string/interval_8_hour</item>
         <item>@string/interval_24_hour</item>
+        <item>@string/interval_always_ask</item>
     </string-array>
 
     <string-array name="snooze_interval_values" translatable="false">
@@ -45,6 +46,7 @@
         <item>240</item>
         <item>480</item>
         <item>1440</item>
+        <item>-1</item>
     </string-array>
 
     <string-array name="frequencyQuickSelect" translatable="false">

--- a/uhabits-android/src/main/res/values/strings.xml
+++ b/uhabits-android/src/main/res/values/strings.xml
@@ -84,6 +84,7 @@
     <string name="interval_8_hour">8 hours</string>
     <string name="interval_24_hour">24 hours</string>
     <string name="interval_always_ask">Always ask</string>
+    <string name="interval_custom">Custom...</string>
     <string name="pref_toggle_title">Toggle with short press</string>
     <string name="pref_toggle_description">Put checkmarks with a single tap instead of press-and-hold. More convenient, but might cause accidental toggles.</string>
     <string name="pref_snooze_interval_title">Snooze interval on reminders</string>
@@ -96,6 +97,7 @@
     <string name="name">Name</string>
     <string name="settings">Settings</string>
     <string name="snooze_interval">Snooze interval</string>
+    <string name="select_snooze_delay">Select snooze delay</string>
 
     <string name="hint_title">Did you know?</string>
     <string name="hint_drag">To rearrange the entries, press-and-hold on the name of the habit, then drag it to the correct place.</string>

--- a/uhabits-android/src/main/res/values/strings.xml
+++ b/uhabits-android/src/main/res/values/strings.xml
@@ -83,6 +83,7 @@
     <string name="interval_4_hour">4 hours</string>
     <string name="interval_8_hour">8 hours</string>
     <string name="interval_24_hour">24 hours</string>
+    <string name="interval_always_ask">Always ask</string>
     <string name="pref_toggle_title">Toggle with short press</string>
     <string name="pref_toggle_description">Put checkmarks with a single tap instead of press-and-hold. More convenient, but might cause accidental toggles.</string>
     <string name="pref_snooze_interval_title">Snooze interval on reminders</string>

--- a/uhabits-android/src/test/java/org/isoron/uhabits/receivers/ReminderControllerTest.java
+++ b/uhabits-android/src/test/java/org/isoron/uhabits/receivers/ReminderControllerTest.java
@@ -70,7 +70,7 @@ public class ReminderControllerTest extends BaseAndroidJVMTest
         DateUtils.setFixedLocalTime(now);
         when(preferences.getSnoozeInterval()).thenReturn(15L);
 
-        controller.onSnooze(habit);
+        controller.onSnooze(habit,null);
 
         verify(reminderScheduler).schedule(habit, nowTz + 900000);
         verify(notificationTray).cancel(habit);


### PR DESCRIPTION
Note that this is sort of a work in progress. Although the code seems to work ok and is usable, I'm new not only to the app but to Android/Java in general, and some of the things in these commits feel a bit hackish, so I thought I'd better get some feedback.

These changes implement another option "Always ask" for the snooze delay, resulting in the Snooze button in the notifications opening a time picker dialog, and snoozing the reminder until that time. What should also be implemented but isn't yet is first showing a popup with a list of the preset snooze delays, which would just snooze for the given time, and extra option "Custom" leading to the time picker dialog.
