### PR TITLE
avoid sql error when updating sql database

### DIFF
--- a/uhabits-core/src/main/resources/migrations/22.sql
+++ b/uhabits-core/src/main/resources/migrations/22.sql
@@ -13,7 +13,7 @@ begin transaction;
         habit integer not null references habits(id),
         timestamp integer not null,
         value integer not null);
-    drop index idx_repetitions_habit_timestamp;
+    drop index if exists idx_repetitions_habit_timestamp;
     create unique index idx_repetitions_habit_timestamp on Repetitions(
         habit, timestamp);
     insert into Repetitions select * from RepetitionsBak;


### PR DESCRIPTION
The index doesn't exist in version 1.7.6 and so trying to drop it
would lead to an error, resulting in not being able to import
1.7.6 database.
https://github.com/iSoron/uhabits/issues/327