### PR TITLE
don't reset habit position when editing it

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/edit/EditHabitDialog.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/edit/EditHabitDialog.java
@@ -171,6 +171,8 @@ public class EditHabitDialog extends AppCompatDialogFragment
         if (type == Habit.NUMBER_HABIT && !targetPanel.validate()) return;
 
         Habit habit = modelFactory.buildHabit();
+        if( originalHabit != null )
+            habit.copyFrom(originalHabit);
         habit.setName(namePanel.getName());
         habit.setDescription(namePanel.getDescription());
         habit.setColor(namePanel.getColor());


### PR DESCRIPTION
Without this, merely hitting "Save" in the edit dialog reset Habit's position to 0, as it seems such internal data is not kept while editing.
