### PR TITLE
synchronize HabitList properly

### DIFF
--- a/uhabits-core/src/main/java/org/isoron/uhabits/core/models/memory/MemoryHabitList.java
+++ b/uhabits-core/src/main/java/org/isoron/uhabits/core/models/memory/MemoryHabitList.java
@@ -155,14 +155,14 @@ public class MemoryHabitList extends HabitList
     }
 
     @Override
-    public int indexOf(@NonNull Habit h)
+    public synchronized int indexOf(@NonNull Habit h)
     {
         return list.indexOf(h);
     }
 
     @NonNull
     @Override
-    public Iterator<Habit> iterator()
+    public synchronized Iterator<Habit> iterator()
     {
         return Collections.unmodifiableCollection(list).iterator();
     }
@@ -200,13 +200,13 @@ public class MemoryHabitList extends HabitList
     }
 
     @Override
-    public int size()
+    public synchronized int size()
     {
         return list.size();
     }
 
     @Override
-    public void update(List<Habit> habits)
+    public synchronized void update(List<Habit> habits)
     {
         resort();
         getObservable().notifyListeners();

--- a/uhabits-core/src/main/java/org/isoron/uhabits/core/models/sqlite/SQLiteHabitList.java
+++ b/uhabits-core/src/main/java/org/isoron/uhabits/core/models/sqlite/SQLiteHabitList.java
@@ -91,7 +91,7 @@ public class SQLiteHabitList extends HabitList
 
     @Override
     @Nullable
-    public Habit getById(long id)
+    public synchronized Habit getById(long id)
     {
         loadRecords();
         return list.getById(id);
@@ -99,7 +99,7 @@ public class SQLiteHabitList extends HabitList
 
     @Override
     @NonNull
-    public Habit getByPosition(int position)
+    public synchronized Habit getByPosition(int position)
     {
         loadRecords();
         return list.getByPosition(position);
@@ -107,7 +107,7 @@ public class SQLiteHabitList extends HabitList
 
     @NonNull
     @Override
-    public HabitList getFiltered(HabitMatcher filter)
+    public synchronized HabitList getFiltered(HabitMatcher filter)
     {
         loadRecords();
         return list.getFiltered(filter);
@@ -121,21 +121,21 @@ public class SQLiteHabitList extends HabitList
     }
 
     @Override
-    public void setOrder(@NonNull Order order)
+    public synchronized void setOrder(@NonNull Order order)
     {
         list.setOrder(order);
         getObservable().notifyListeners();
     }
 
     @Override
-    public int indexOf(@NonNull Habit h)
+    public synchronized int indexOf(@NonNull Habit h)
     {
         loadRecords();
         return list.indexOf(h);
     }
 
     @Override
-    public Iterator<Habit> iterator()
+    public synchronized Iterator<Habit> iterator()
     {
         loadRecords();
         return list.iterator();
@@ -214,7 +214,7 @@ public class SQLiteHabitList extends HabitList
     }
 
     @Override
-    public void repair()
+    public synchronized void repair()
     {
         loadRecords();
         rebuildOrder();
@@ -222,7 +222,7 @@ public class SQLiteHabitList extends HabitList
     }
 
     @Override
-    public int size()
+    public synchronized int size()
     {
         loadRecords();
         return list.size();
@@ -245,7 +245,7 @@ public class SQLiteHabitList extends HabitList
         getObservable().notifyListeners();
     }
 
-    public void reload()
+    public synchronized void reload()
     {
         loaded = false;
     }


### PR DESCRIPTION
When the app is not running and ReminderReceiver receives ACTION_SHOW_REMINDER,
the (SQLite)HabitList will start loading its data in the background for some
reason, and if the loading takes a moment, ReminderReceiver will call
the unsynchronized HabitList.getById() before the loading finishes,
failing to find the habit for which to show the notification.

I originally submitted this only as https://github.com/iSoron/uhabits/issues/338 , but since this commit fixes a problem and I don't see a regression compared to dev, I've simply created a pull request and the other stuff can be handled later.
