### PR TITLE
Save snoozed reminders

### DIFF
--- a/android-pickers/src/main/java/com/android/datetimepicker/time/TimePickerDialog.java
+++ b/android-pickers/src/main/java/com/android/datetimepicker/time/TimePickerDialog.java
@@ -63,6 +63,7 @@ public class TimePickerDialog extends AppCompatDialogFragment implements OnValue
     private static final int PULSE_ANIMATOR_DELAY = 300;
 
     private OnTimeSetListener mCallback;
+    private DialogInterface.OnDismissListener dismissListener;
 
     private HapticFeedbackController mHapticFeedbackController;
 
@@ -997,5 +998,16 @@ public class TimePickerDialog extends AppCompatDialogFragment implements OnValue
             }
             return false;
         }
+    }
+
+    public void setDismissListener( DialogInterface.OnDismissListener listener ) {
+        dismissListener = listener;
+    }
+
+    @Override
+    public void onDismiss(DialogInterface dialog) {
+        super.onDismiss(dialog);
+        if( dismissListener != null )
+            dismissListener.onDismiss(dialog);
     }
 }

--- a/uhabits-android/src/androidTest/java/org/isoron/uhabits/reminders/CustomRemindersSaverXmlTest.java
+++ b/uhabits-android/src/androidTest/java/org/isoron/uhabits/reminders/CustomRemindersSaverXmlTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2017 Álinson Santos Xavier <isoron@gmail.com>
+ *
+ * This file is part of Loop Habit Tracker.
+ *
+ * Loop Habit Tracker is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * Loop Habit Tracker is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.isoron.uhabits.reminders;
+
+import android.support.test.filters.*;
+import android.support.test.runner.*;
+
+import org.isoron.uhabits.*;
+import org.junit.*;
+import org.junit.runner.*;
+
+import java.util.*;
+
+@RunWith(AndroidJUnit4.class)
+@MediumTest
+public class CustomRemindersSaverXmlTest extends BaseAndroidTest
+{
+    @Test
+    public void testSaveLoad()
+    {
+        CustomRemindersSaverXml saver = new CustomRemindersSaverXml( targetContext );
+        HashMap< Long, Long > map = new HashMap< Long, Long >();
+        map.put( 1L, 1L );
+        map.put( 2L, 3L );
+        map.put( 3L, 1L );
+        saver.save( map );
+        Map< Long, Long > map2 = saver.load();
+        assertEquals( map, map2 );
+    }
+}

--- a/uhabits-android/src/main/AndroidManifest.xml
+++ b/uhabits-android/src/main/AndroidManifest.xml
@@ -91,7 +91,11 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activities.habits.list.ListHabitsActivity"/>
         </activity>
-        <activity android:name=".notifications.SnoozeDelayActivity"></activity>
+        <activity android:name=".notifications.SnoozeDelayActivity"
+            android:excludeFromRecents="true"
+            android:launchMode="singleInstance"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar">
+        </activity>
 
         <receiver
             android:name=".widgets.CheckmarkWidgetProvider"

--- a/uhabits-android/src/main/AndroidManifest.xml
+++ b/uhabits-android/src/main/AndroidManifest.xml
@@ -91,6 +91,7 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activities.habits.list.ListHabitsActivity"/>
         </activity>
+        <activity android:name=".notifications.SnoozeDelayActivity"></activity>
 
         <receiver
             android:name=".widgets.CheckmarkWidgetProvider"

--- a/uhabits-android/src/main/java/org/isoron/uhabits/HabitsApplication.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/HabitsApplication.kt
@@ -25,6 +25,7 @@ import org.isoron.androidbase.*
 import org.isoron.uhabits.core.database.*
 import org.isoron.uhabits.core.reminders.*
 import org.isoron.uhabits.core.ui.*
+import org.isoron.uhabits.reminders.*
 import org.isoron.uhabits.utils.*
 import org.isoron.uhabits.widgets.*
 import java.io.*
@@ -64,6 +65,7 @@ class HabitsApplication : Application() {
         widgetUpdater.startListening()
 
         reminderScheduler = component.reminderScheduler
+        reminderScheduler.setCustomRemindersSaver( CustomRemindersSaverXml( context ))
         reminderScheduler.startListening()
 
         notificationTray = component.notificationTray

--- a/uhabits-android/src/main/java/org/isoron/uhabits/notifications/SnoozeDelayActivity.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/notifications/SnoozeDelayActivity.java
@@ -4,6 +4,7 @@ import android.app.*;
 import android.content.*;
 import android.os.*;
 import android.support.v4.app.*;
+import android.support.v7.view.*;
 import android.text.format.*;
 import android.util.*;
 
@@ -50,7 +51,10 @@ public class SnoozeDelayActivity extends FragmentActivity implements
 
     private void AskSnooze()
     {
-        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        HabitsApplicationComponent component = ((HabitsApplication) getApplicationContext()).getComponent();
+        int theme = component.getPreferences().getTheme() == THEME_DARK
+                ? R.style.Theme_AppCompat_Dialog_Alert : R.style.Theme_AppCompat_Light_Dialog_Alert;
+        AlertDialog.Builder builder = new AlertDialog.Builder(new ContextThemeWrapper(this, theme));
         builder.setTitle(R.string.select_snooze_delay)
                 .setItems(R.array.snooze_interval_names_reminder, this);
         AlertDialog dialog = builder.create();

--- a/uhabits-android/src/main/java/org/isoron/uhabits/notifications/SnoozeDelayActivity.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/notifications/SnoozeDelayActivity.java
@@ -1,0 +1,85 @@
+package org.isoron.uhabits.notifications;
+
+import android.content.*;
+import android.os.*;
+import android.support.v4.app.*;
+import android.text.format.*;
+import android.util.*;
+
+import com.android.datetimepicker.time.*;
+
+import org.isoron.uhabits.core.utils.DateUtils;
+import org.isoron.uhabits.receivers.*;
+
+import java.util.*;
+
+import static org.isoron.uhabits.core.utils.DateUtils.applyTimezone;
+
+public class SnoozeDelayActivity extends FragmentActivity implements
+        TimePickerDialog.OnTimeSetListener {
+
+    public static final String ACTION_ASK_SNOOZE = "org.isoron.uhabits.ACTION_ASK_SNOOZE";
+
+    private static final String TAG = "SnoozeDelayActivity";
+
+    @Override
+    protected void onCreate(Bundle bundle)
+    {
+        super.onCreate(bundle);
+        Intent intent = getIntent();
+        try
+        {
+            switch (intent.getAction())
+            {
+                case ACTION_ASK_SNOOZE:
+                    AskSnooze();
+                    break;
+            }
+        }
+        catch (RuntimeException e)
+        {
+            Log.e(TAG, "could not process intent", e);
+        }
+    }
+
+    private void AskSnooze()
+    {
+        final Calendar calendar = Calendar.getInstance();
+        int hour = calendar.get(Calendar.HOUR_OF_DAY);
+        int minute = calendar.get(Calendar.MINUTE);
+        TimePickerDialog dialog;
+        dialog = TimePickerDialog.newInstance(this,
+                hour, minute, DateFormat.is24HourFormat(this));
+        dialog.show(getSupportFragmentManager(),"timePicker");
+    }
+
+    @Override
+    public void onTimeSet(RadialPickerLayout view, int hourOfDay, int minute)
+    {
+        Calendar calendar = DateUtils.getStartOfTodayCalendar();
+        calendar.set(Calendar.HOUR_OF_DAY, hourOfDay);
+        calendar.set(Calendar.MINUTE, minute);
+        calendar.set(Calendar.SECOND, 0);
+        Long time = calendar.getTimeInMillis();
+        if (DateUtils.getLocalTime() > time)
+            time += DateUtils.DAY_LENGTH;
+        time = applyTimezone(time);
+
+        Intent intent = new Intent( ReminderReceiver.ACTION_SNOOZE_REMINDER_SET, getIntent().getData(),
+                this, ReminderReceiver.class );
+        intent.putExtra("reminderTime", time);
+        sendBroadcast(intent);
+
+        finish();
+    }
+
+    @Override
+    public void onTimeCleared(RadialPickerLayout view)
+    {
+        Intent intent = new Intent( ReminderReceiver.ACTION_DISMISS_REMINDER, getIntent().getData(),
+                this, ReminderReceiver.class );
+        sendBroadcast(intent);
+
+        finish();
+    }
+}

--- a/uhabits-android/src/main/java/org/isoron/uhabits/notifications/SnoozeDelayActivity.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/notifications/SnoozeDelayActivity.java
@@ -18,7 +18,7 @@ import static org.isoron.uhabits.core.ui.ThemeSwitcher.THEME_DARK;
 import static org.isoron.uhabits.core.utils.DateUtils.applyTimezone;
 
 public class SnoozeDelayActivity extends FragmentActivity implements
-        TimePickerDialog.OnTimeSetListener {
+        TimePickerDialog.OnTimeSetListener, DialogInterface.OnDismissListener {
 
     public static final String ACTION_ASK_SNOOZE = "org.isoron.uhabits.ACTION_ASK_SNOOZE";
 
@@ -54,6 +54,7 @@ public class SnoozeDelayActivity extends FragmentActivity implements
                 hour, minute, DateFormat.is24HourFormat(this));
         HabitsApplicationComponent component = ((HabitsApplication) getApplicationContext()).getComponent();
         dialog.setThemeDark(component.getPreferences().getTheme() == THEME_DARK);
+        dialog.setDismissListener(this);
         dialog.show(getSupportFragmentManager(),"timePicker");
     }
 
@@ -73,8 +74,6 @@ public class SnoozeDelayActivity extends FragmentActivity implements
                 this, ReminderReceiver.class );
         intent.putExtra("reminderTime", time);
         sendBroadcast(intent);
-
-        finish();
     }
 
     @Override
@@ -83,7 +82,11 @@ public class SnoozeDelayActivity extends FragmentActivity implements
         Intent intent = new Intent( ReminderReceiver.ACTION_DISMISS_REMINDER, getIntent().getData(),
                 this, ReminderReceiver.class );
         sendBroadcast(intent);
+    }
 
+    @Override
+    public void onDismiss(DialogInterface dialogInterface)
+    {
         finish();
     }
 }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/notifications/SnoozeDelayActivity.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/notifications/SnoozeDelayActivity.java
@@ -8,11 +8,13 @@ import android.util.*;
 
 import com.android.datetimepicker.time.*;
 
+import org.isoron.uhabits.*;
 import org.isoron.uhabits.core.utils.DateUtils;
 import org.isoron.uhabits.receivers.*;
 
 import java.util.*;
 
+import static org.isoron.uhabits.core.ui.ThemeSwitcher.THEME_DARK;
 import static org.isoron.uhabits.core.utils.DateUtils.applyTimezone;
 
 public class SnoozeDelayActivity extends FragmentActivity implements
@@ -50,6 +52,8 @@ public class SnoozeDelayActivity extends FragmentActivity implements
         TimePickerDialog dialog;
         dialog = TimePickerDialog.newInstance(this,
                 hour, minute, DateFormat.is24HourFormat(this));
+        HabitsApplicationComponent component = ((HabitsApplication) getApplicationContext()).getComponent();
+        dialog.setThemeDark(component.getPreferences().getTheme() == THEME_DARK);
         dialog.show(getSupportFragmentManager(),"timePicker");
     }
 

--- a/uhabits-android/src/main/java/org/isoron/uhabits/receivers/ReminderController.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/receivers/ReminderController.java
@@ -65,7 +65,7 @@ public class ReminderController
                                long reminderTime)
     {
         notificationTray.show(habit, timestamp, reminderTime);
-        reminderScheduler.scheduleAll();
+        reminderScheduler.scheduleHabitAtReminder(habit);
     }
 
     public void onSnooze(@NonNull Habit habit, final Context context)

--- a/uhabits-android/src/main/java/org/isoron/uhabits/receivers/ReminderController.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/receivers/ReminderController.java
@@ -94,7 +94,7 @@ public class ReminderController
 
     public void snoozeNotificationSetReminderTime(@NonNull Habit habit, long reminderTime)
     {
-        reminderScheduler.schedule(habit, reminderTime);
+        reminderScheduler.scheduleHabitAtCustom(habit, reminderTime);
         notificationTray.cancel(habit);
     }
 

--- a/uhabits-android/src/main/java/org/isoron/uhabits/receivers/ReminderReceiver.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/receivers/ReminderReceiver.java
@@ -49,6 +49,9 @@ public class ReminderReceiver extends BroadcastReceiver
     public static final String ACTION_SNOOZE_REMINDER_SET =
             "org.isoron.uhabits.ACTION_SNOOZE_REMINDER_SET";
 
+    public static final String ACTION_SNOOZE_REMINDER_DELAY =
+            "org.isoron.uhabits.ACTION_SNOOZE_REMINDER_DELAY";
+
     private static final String TAG = "ReminderReceiver";
 
     @Override
@@ -99,6 +102,12 @@ public class ReminderReceiver extends BroadcastReceiver
                 case ACTION_SNOOZE_REMINDER_SET:
                     if (habit == null) return;
                     reminderController.snoozeNotificationSetReminderTime(habit, reminderTime);
+                    break;
+
+                case ACTION_SNOOZE_REMINDER_DELAY:
+                    if (habit == null) return;
+                    long snoozeDelay = intent.getIntExtra("snoozeDelay", 0);
+                    reminderController.snoozeNotificationAddDelay(habit, snoozeDelay);
                     break;
 
                 case Intent.ACTION_BOOT_COMPLETED:

--- a/uhabits-android/src/main/java/org/isoron/uhabits/receivers/ReminderReceiver.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/receivers/ReminderReceiver.java
@@ -46,6 +46,9 @@ public class ReminderReceiver extends BroadcastReceiver
     public static final String ACTION_SNOOZE_REMINDER =
         "org.isoron.uhabits.ACTION_SNOOZE_REMINDER";
 
+    public static final String ACTION_SNOOZE_REMINDER_SET =
+            "org.isoron.uhabits.ACTION_SNOOZE_REMINDER_SET";
+
     private static final String TAG = "ReminderReceiver";
 
     @Override
@@ -90,7 +93,12 @@ public class ReminderReceiver extends BroadcastReceiver
 
                 case ACTION_SNOOZE_REMINDER:
                     if (habit == null) return;
-                    reminderController.onSnooze(habit);
+                    reminderController.onSnooze(habit,context);
+                    break;
+
+                case ACTION_SNOOZE_REMINDER_SET:
+                    if (habit == null) return;
+                    reminderController.snoozeNotificationSetReminderTime(habit, reminderTime);
                     break;
 
                 case Intent.ACTION_BOOT_COMPLETED:

--- a/uhabits-android/src/main/java/org/isoron/uhabits/reminders/CustomRemindersSaverXml.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/reminders/CustomRemindersSaverXml.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2017 Álinson Santos Xavier <isoron@gmail.com>
+ *
+ * This file is part of Loop Habit Tracker.
+ *
+ * Loop Habit Tracker is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * Loop Habit Tracker is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.isoron.uhabits.reminders;
+
+import android.content.*;
+import android.support.annotation.*;
+import android.util.*;
+
+import org.isoron.uhabits.*;
+import org.isoron.uhabits.core.reminders.*;
+import org.w3c.dom.*;
+import org.xml.sax.*;
+import org.xmlpull.v1.*;
+
+import java.io.*;
+import java.util.*;
+
+import javax.xml.parsers.*;
+
+public class CustomRemindersSaverXml implements CustomReminders.Saver
+{
+    private static final String FILENAME_NORMAL = "custom_reminders.xml";
+    private static final String FILENAME_DEBUG = "custom_reminders_debug.xml";
+    private static final String TAG = "CustomRemindersSaverXml";
+
+    private Context context;
+
+    private String filename()
+    {
+        return HabitsApplication.Companion.isTestMode() ? FILENAME_DEBUG : FILENAME_NORMAL;
+    }
+
+    public CustomRemindersSaverXml(@NonNull Context context)
+    {
+        this.context = context;
+    }
+
+    @Override
+    public void save(Map<Long, Long> map)
+    {
+        StringWriter writer = new StringWriter();
+        try
+        {
+            XmlSerializer serializer = Xml.newSerializer();
+            serializer.setOutput( writer );
+            serializer.startDocument("UTF-8", true);
+            serializer.startTag( "","reminders" );
+            for( Map.Entry< Long, Long > entry : map.entrySet())
+            {
+                serializer.startTag( "", "reminder" );
+                serializer.attribute( "", "habitId", entry.getKey().toString());
+                serializer.attribute( "", "time", entry.getValue().toString());
+                serializer.endTag( "", "reminder" );
+            }
+            serializer.endTag( "", "reminders" );
+            serializer.endDocument();
+        } catch (IOException e)
+        {
+            Log.e( TAG, "Error writing XML for custom reminders" );
+            context.getFileStreamPath( filename()).delete();
+            return;
+        }
+        try
+        {
+            FileOutputStream out = context.openFileOutput( filename(), Context.MODE_PRIVATE);
+            out.write( writer.toString().getBytes());
+            out.close();
+        }
+        catch (IOException e)
+        {
+            Log.e( TAG, "Error creating XML file for custom reminders" );
+            context.getFileStreamPath( filename()).delete();
+        }
+    }
+
+    @Override
+    public Map<Long, Long> load()
+    {
+        Map< Long, Long > map = new HashMap< Long, Long >();
+        try
+        {
+            InputStream in = context.openFileInput( filename());
+            if( in != null )
+            {
+                try
+                {
+                    DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+                    Document doc = builder.parse( in );
+                    NodeList nodes = doc.getElementsByTagName( "reminder" );
+                    for( int i = 0; i < nodes.getLength(); ++i )
+                    {
+                        Element element = (Element) nodes.item(i);
+                        Long habitId = Long.parseLong(element.getAttribute("habitId"));
+                        Long time = Long.parseLong(element.getAttribute("time"));
+                        map.put(habitId, time);
+                    }
+                }
+                catch (SAXException | ParserConfigurationException e)
+                {
+                    Log.e( TAG, "Error reading custom reminders XML");
+                }
+                in.close();
+            }
+        }
+        catch (IOException e)
+        {
+            Log.d( TAG, "Custom reminders XML file not found");
+        }
+        return map;
+    }
+}

--- a/uhabits-android/src/main/res/values/constants.xml
+++ b/uhabits-android/src/main/res/values/constants.xml
@@ -49,6 +49,28 @@
         <item>-1</item>
     </string-array>
 
+    <string-array name="snooze_interval_names_reminder">
+        <item>@string/interval_15_minutes</item>
+        <item>@string/interval_30_minutes</item>
+        <item>@string/interval_1_hour</item>
+        <item>@string/interval_2_hour</item>
+        <item>@string/interval_4_hour</item>
+        <item>@string/interval_8_hour</item>
+        <item>@string/interval_24_hour</item>
+        <item>@string/interval_custom</item>
+    </string-array>
+
+    <integer-array name="snooze_interval_values_reminder" translatable="false">
+        <item>15</item>
+        <item>30</item>
+        <item>60</item>
+        <item>120</item>
+        <item>240</item>
+        <item>480</item>
+        <item>1440</item>
+        <item>-1</item>
+    </integer-array>
+
     <string-array name="frequencyQuickSelect" translatable="false">
         <item>@string/every_day</item>
         <item>@string/every_week</item>

--- a/uhabits-android/src/main/res/values/constants.xml
+++ b/uhabits-android/src/main/res/values/constants.xml
@@ -35,6 +35,7 @@
         <item>@string/interval_4_hour</item>
         <item>@string/interval_8_hour</item>
         <item>@string/interval_24_hour</item>
+        <item>@string/interval_always_ask</item>
     </string-array>
 
     <string-array name="snooze_interval_values" translatable="false">
@@ -45,6 +46,7 @@
         <item>240</item>
         <item>480</item>
         <item>1440</item>
+        <item>-1</item>
     </string-array>
 
     <string-array name="frequencyQuickSelect" translatable="false">

--- a/uhabits-android/src/main/res/values/strings.xml
+++ b/uhabits-android/src/main/res/values/strings.xml
@@ -84,6 +84,7 @@
     <string name="interval_8_hour">8 hours</string>
     <string name="interval_24_hour">24 hours</string>
     <string name="interval_always_ask">Always ask</string>
+    <string name="interval_custom">Custom...</string>
     <string name="pref_toggle_title">Toggle with short press</string>
     <string name="pref_toggle_description">Put checkmarks with a single tap instead of press-and-hold. More convenient, but might cause accidental toggles.</string>
     <string name="pref_snooze_interval_title">Snooze interval on reminders</string>
@@ -96,6 +97,7 @@
     <string name="name">Name</string>
     <string name="settings">Settings</string>
     <string name="snooze_interval">Snooze interval</string>
+    <string name="select_snooze_delay">Select snooze delay</string>
 
     <string name="hint_title">Did you know?</string>
     <string name="hint_drag">To rearrange the entries, press-and-hold on the name of the habit, then drag it to the correct place.</string>

--- a/uhabits-android/src/main/res/values/strings.xml
+++ b/uhabits-android/src/main/res/values/strings.xml
@@ -83,6 +83,7 @@
     <string name="interval_4_hour">4 hours</string>
     <string name="interval_8_hour">8 hours</string>
     <string name="interval_24_hour">24 hours</string>
+    <string name="interval_always_ask">Always ask</string>
     <string name="pref_toggle_title">Toggle with short press</string>
     <string name="pref_toggle_description">Put checkmarks with a single tap instead of press-and-hold. More convenient, but might cause accidental toggles.</string>
     <string name="pref_snooze_interval_title">Snooze interval on reminders</string>

--- a/uhabits-android/src/test/java/org/isoron/uhabits/receivers/ReminderControllerTest.java
+++ b/uhabits-android/src/test/java/org/isoron/uhabits/receivers/ReminderControllerTest.java
@@ -82,7 +82,7 @@ public class ReminderControllerTest extends BaseAndroidJVMTest
         Habit habit = mock(Habit.class);
         controller.onShowReminder(habit, Timestamp.ZERO.plus(100), 456);
         verify(notificationTray).show(habit, Timestamp.ZERO.plus(100), 456);
-        verify(reminderScheduler).scheduleAll();
+        verify(reminderScheduler).scheduleHabitAtReminder(habit);
     }
 
     @Test

--- a/uhabits-android/src/test/java/org/isoron/uhabits/receivers/ReminderControllerTest.java
+++ b/uhabits-android/src/test/java/org/isoron/uhabits/receivers/ReminderControllerTest.java
@@ -72,7 +72,7 @@ public class ReminderControllerTest extends BaseAndroidJVMTest
 
         controller.onSnooze(habit,null);
 
-        verify(reminderScheduler).schedule(habit, nowTz + 900000);
+        verify(reminderScheduler).scheduleHabitAtCustom(habit, nowTz + 900000);
         verify(notificationTray).cancel(habit);
     }
 

--- a/uhabits-android/src/test/java/org/isoron/uhabits/receivers/ReminderControllerTest.java
+++ b/uhabits-android/src/test/java/org/isoron/uhabits/receivers/ReminderControllerTest.java
@@ -70,7 +70,7 @@ public class ReminderControllerTest extends BaseAndroidJVMTest
         DateUtils.setFixedLocalTime(now);
         when(preferences.getSnoozeInterval()).thenReturn(15L);
 
-        controller.onSnooze(habit);
+        controller.onSnooze(habit,null);
 
         verify(reminderScheduler).schedule(habit, nowTz + 900000);
         verify(notificationTray).cancel(habit);

--- a/uhabits-core/src/main/java/org/isoron/uhabits/core/commands/DeleteHabitsCommand.java
+++ b/uhabits-core/src/main/java/org/isoron/uhabits/core/commands/DeleteHabitsCommand.java
@@ -69,6 +69,14 @@ public class DeleteHabitsCommand extends Command
         throw new UnsupportedOperationException();
     }
 
+    public List<Long> getHabitIds()
+    {
+        List<Long> list = new LinkedList<Long>();
+        for( Habit habit: selected)
+            list.add(habit.getId());
+        return list;
+    }
+
     public static class Record
     {
         @NonNull

--- a/uhabits-core/src/main/java/org/isoron/uhabits/core/commands/EditHabitCommand.java
+++ b/uhabits-core/src/main/java/org/isoron/uhabits/core/commands/EditHabitCommand.java
@@ -137,4 +137,6 @@ public class EditHabitCommand extends Command
             return command;
         }
     }
+
+    public Long getHabitId() { return  savedId; }
 }

--- a/uhabits-core/src/main/java/org/isoron/uhabits/core/reminders/CustomReminders.java
+++ b/uhabits-core/src/main/java/org/isoron/uhabits/core/reminders/CustomReminders.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2017 Álinson Santos Xavier <isoron@gmail.com>
+ *
+ * This file is part of Loop Habit Tracker.
+ *
+ * Loop Habit Tracker is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * Loop Habit Tracker is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.isoron.uhabits.core.reminders;
+
+import android.support.annotation.*;
+
+import java.util.*;
+
+public class CustomReminders
+{
+    private Map< Long, Long > map; // Habit id, Timestamp
+
+    private Saver saver;
+
+    CustomReminders()
+    {
+        map = new HashMap< Long, Long >();
+    }
+
+    public void setSaver( Saver saver )
+    {
+        this.saver = saver;
+        if( saver != null )
+            map = saver.load();
+    }
+
+    public void set(@NonNull Long habitId, @NonNull Long reminderTime)
+    {
+        map.put( habitId, reminderTime );
+        save();
+    }
+
+    public void remove(@NonNull Long habitId )
+    {
+        if( map.remove( habitId ) != null )
+            save();
+    }
+
+    public Long get( @NonNull Long habitId )
+    {
+        return map.get( habitId );
+    }
+
+    private void save()
+    {
+        if( saver != null )
+            saver.save( map );
+    }
+
+    public interface Saver
+    {
+        void save( Map< Long, Long > map);
+        Map< Long, Long > load();
+    }
+}

--- a/uhabits-core/src/main/java/org/isoron/uhabits/core/reminders/ReminderScheduler.java
+++ b/uhabits-core/src/main/java/org/isoron/uhabits/core/reminders/ReminderScheduler.java
@@ -41,7 +41,7 @@ public class ReminderScheduler implements CommandRunner.Listener
 
     private SystemScheduler sys;
 
-    private Map< Long, Long > customReminders; // Habit id, Timestamp
+    private CustomReminders customReminders;
 
     @Inject
     public ReminderScheduler(@NonNull CommandRunner commandRunner,
@@ -51,7 +51,12 @@ public class ReminderScheduler implements CommandRunner.Listener
         this.commandRunner = commandRunner;
         this.habitList = habitList;
         this.sys = sys;
-        customReminders = new HashMap< Long, Long >();
+        this.customReminders = new CustomReminders();
+    }
+
+    public void setCustomRemindersSaver( CustomReminders.Saver saver )
+    {
+        customReminders.setSaver( saver );
     }
 
     @Override
@@ -81,8 +86,7 @@ public class ReminderScheduler implements CommandRunner.Listener
     public void scheduleHabit(@NonNull Habit habit)
     {
         Long reminderTime = null;
-        if( customReminders.containsKey( habit.getId()))
-            reminderTime = customReminders.get( habit.getId());
+        reminderTime = customReminders.get( habit.getId());
         scheduleInternal(habit, reminderTime);
     }
 
@@ -94,7 +98,7 @@ public class ReminderScheduler implements CommandRunner.Listener
 
     public void scheduleHabitAtCustom(@NonNull Habit habit, @NonNull Long reminderTime)
     {
-        customReminders.put( habit.getId(), reminderTime );
+        customReminders.set( habit.getId(), reminderTime );
         scheduleInternal(habit, reminderTime);
     }
 

--- a/uhabits-core/src/test/java/org/isoron/uhabits/core/reminders/CustomRemindersTest.java
+++ b/uhabits-core/src/test/java/org/isoron/uhabits/core/reminders/CustomRemindersTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2017 Álinson Santos Xavier <isoron@gmail.com>
+ *
+ * This file is part of Loop Habit Tracker.
+ *
+ * Loop Habit Tracker is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * Loop Habit Tracker is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.isoron.uhabits.core.reminders;
+
+import org.hamcrest.*;
+import org.isoron.uhabits.core.*;
+import org.junit.*;
+
+import static org.hamcrest.Matchers.*;
+
+public class CustomRemindersTest extends BaseUnitTest
+{
+    @Test
+    public void ModifyTest()
+    {
+        CustomReminders reminders = new CustomReminders();
+        MatcherAssert.assertThat( reminders.get( 1L ), equalTo( null ));
+        reminders.set( 1L, 1L );
+        MatcherAssert.assertThat( reminders.get( 1L ), equalTo( 1L ));
+        reminders.set( 2L, 2L );
+        MatcherAssert.assertThat( reminders.get( 2L ), equalTo( 2L ));
+        reminders.set( 1L, 3L );
+        MatcherAssert.assertThat( reminders.get( 1L ), equalTo( 3L ));
+        MatcherAssert.assertThat( reminders.get( 2L ), equalTo( 2L ));
+        reminders.remove( 1L );
+        MatcherAssert.assertThat( reminders.get( 1L ), equalTo( null ));
+    }
+}


### PR DESCRIPTION
If a reminder is snoozed, the app may actually discard the snoozed reminder and not show the reminder again, for a number of reasons such as:
- Any (even different) habit is edited, which results in ReminderScheduler.onCommandExecuted() to simply do scheduleAll(), scheduling the snoozed habit at its configured time instead.
- The app is (re)started (be it after version upgrade, or simply because it's no longer running).

These patches implement saving of such snoozed reminders, so that they are not forgotten until they are activated again or discarded.

Note that these changes depend on https://github.com/iSoron/uhabits/pull/332 (included here as the first 5 commits).

