### PR TITLE
Decrease transparency of widgets.

### DIFF
--- a/uhabits-android/src/main/res/values/styles.xml
+++ b/uhabits-android/src/main/res/values/styles.xml
@@ -151,7 +151,7 @@
         <item name="palette">@array/transparentWidgetPalette</item>
 
         <item name="widgetShadowAlpha">0</item>
-        <item name="widgetBackgroundAlpha">0.25</item>
+        <item name="widgetBackgroundAlpha">0.5</item>
     </style>
 
     <style name="day_of_week_label_condensed"/>


### PR DESCRIPTION
Update styles.xml to decrease transparency on widgets. If background image on the phone has too many lines, data and charts are hard to read.