### PR TITLE
Removed API_VERSION < 26 condition for snooze action to be displayed.

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/notifications/AndroidNotificationTray.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/notifications/AndroidNotificationTray.kt
@@ -118,13 +118,12 @@ class AndroidNotificationTray
         if (preferences.shouldMakeNotificationsLed())
             builder.setLights(Color.RED, 1000, 1000)
 
-        if(SDK_INT < Build.VERSION_CODES.O) {
-            val snoozeAction = Action(R.drawable.ic_action_snooze,
-                context.getString(R.string.snooze),
-                pendingIntents.snoozeNotification(habit))
-            wearableExtender.addAction(snoozeAction)
-            builder.addAction(snoozeAction)
-        }
+        val snoozeAction = Action(R.drawable.ic_action_snooze,
+            context.getString(R.string.snooze),
+            pendingIntents.snoozeNotification(habit))
+        wearableExtender.addAction(snoozeAction)
+        builder.addAction(snoozeAction)
+
 
         builder.extend(wearableExtender)
 	    return builder.build()


### PR DESCRIPTION
I started working on this based on https://github.com/iSoron/uhabits/issues/442.

I removed this conditional, since I was not able to see Snooze ("Later") button on my device with app version 1.7.9. My device is Xiaomi Mi A1 running Android v. 8.1.0.

The condition removed did not make any sense to me and fixed the issue.
