### PR TITLE
Allow multiple habits on strength chart

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/views/ScoreCard.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/views/ScoreCard.java
@@ -128,7 +128,6 @@ public class ScoreCard extends HabitCard
         {
             spinner.setVisibility(GONE);
             title.setTextColor(PaletteUtils.getAndroidTestColor(1));
-            chart.setColor(PaletteUtils.getAndroidTestColor(1));
             chart.populateWithRandomData();
         }
     }
@@ -151,7 +150,9 @@ public class ScoreCard extends HabitCard
             if (bucketSize == 1) scores = scoreList.toList();
             else scores = scoreList.groupBy(getTruncateField(bucketSize));
 
-            chart.setScores(scores);
+            List<Habit> habits = new ArrayList<>();
+            habits.add(getHabit());
+            chart.setHabits(habits);
             chart.setBucketSize(bucketSize);
         }
 
@@ -161,7 +162,6 @@ public class ScoreCard extends HabitCard
             int color =
                 PaletteUtils.getColor(getContext(), getHabit().getColor());
             title.setTextColor(color);
-            chart.setColor(color);
         }
     }
 }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/FrequencyWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/FrequencyWidget.kt
@@ -37,7 +37,7 @@ class FrequencyWidget(
 
     override fun refreshData(v: View) {
         val widgetView = v as GraphWidgetView
-        widgetView.setTitle(habit.name)
+        widgetView.setHabits(listOf(habit))
         (widgetView.dataView as FrequencyChart).apply {
             setColor(PaletteUtils.getColor(context, habit.color))
             setFrequency(habit.repetitions.weekdayFrequency)

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/HistoryWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/HistoryWidget.kt
@@ -47,7 +47,7 @@ class HistoryWidget(
 
     override fun buildView() =
             GraphWidgetView(context, HistoryChart(context)).apply {
-                setTitle(habit.name)
+                setHabits(listOf(habit))
             }
 
     override fun getDefaultHeight() = 250

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/ScoreWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/ScoreWidget.kt
@@ -24,37 +24,31 @@ import android.view.*
 import org.isoron.uhabits.activities.common.views.*
 import org.isoron.uhabits.activities.habits.show.views.*
 import org.isoron.uhabits.core.models.*
-import org.isoron.uhabits.utils.*
 import org.isoron.uhabits.widgets.views.*
 
 class ScoreWidget(
         context: Context,
         id: Int,
-        private val habit: Habit
+        private val habits: List<Habit>
 ) : BaseWidget(context, id) {
 
     override fun getOnClickPendingIntent(context: Context) =
-            pendingIntentFactory.showHabit(habit)
+            pendingIntentFactory.showHabit(habits.get(0))
 
     override fun refreshData(view: View) {
         val size = ScoreCard.BUCKET_SIZES[prefs.defaultScoreSpinnerPosition]
-        val scores = when(size) {
-            1 -> habit.scores.toList()
-            else -> habit.scores.groupBy(ScoreCard.getTruncateField(size))
-        }
 
         val widgetView = view as GraphWidgetView
         (widgetView.dataView as ScoreChart).apply {
             setIsTransparencyEnabled(true)
             setBucketSize(size)
-            setColor(PaletteUtils.getColor(context, habit.color))
-            setScores(scores)
+            setHabits(habits)
         }
     }
 
     override fun buildView() =
             GraphWidgetView(context, ScoreChart(context)).apply {
-                setTitle(habit.name)
+                setHabits(habits)
             }
 
     override fun getDefaultHeight() = 300

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/ScoreWidgetProvider.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/ScoreWidgetProvider.kt
@@ -23,7 +23,6 @@ import android.content.*
 class ScoreWidgetProvider : BaseWidgetProvider() {
     override fun getWidgetFromId(context: Context, id: Int): BaseWidget {
         val habits = getHabitsFromWidgetId(id)
-        if (habits.size == 1) return ScoreWidget(context, id, habits[0])
-        else return StackWidget(context, id, StackWidgetType.SCORE, habits)
+        return ScoreWidget(context, id, habits)
     }
 }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/StackWidgetService.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/StackWidgetService.java
@@ -95,8 +95,11 @@ class StackRemoteViewsFactory implements RemoteViewsService.RemoteViewsFactory
                 return new CheckmarkWidget(context, widgetId, habit);
             case FREQUENCY:
                 return new FrequencyWidget(context, widgetId, habit);
-            case SCORE:
-                return new ScoreWidget(context, widgetId, habit);
+            case SCORE:{
+                List<Habit> list = new ArrayList<>();
+                list.add(habit);
+                return new ScoreWidget(context, widgetId, list);
+            }
             case HISTORY:
                 return new HistoryWidget(context, widgetId, habit);
             case STREAKS:

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/StreakWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/StreakWidget.kt
@@ -47,7 +47,7 @@ class StreakWidget(
 
     override fun buildView(): View {
         return GraphWidgetView(context, StreakChart(context)).apply {
-            setTitle(habit.name)
+            setHabits(listOf(habit))
             layoutParams = LayoutParams(MATCH_PARENT, MATCH_PARENT)
         }
     }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/views/GraphWidgetView.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/views/GraphWidgetView.java
@@ -20,18 +20,25 @@
 package org.isoron.uhabits.widgets.views;
 
 import android.content.*;
+import android.graphics.Color;
 import android.support.annotation.*;
 import android.view.*;
 import android.widget.*;
 
 import org.isoron.uhabits.*;
+import org.isoron.uhabits.core.models.Habit;
+import org.isoron.uhabits.utils.PaletteUtils;
+
+import java.util.List;
 
 public class GraphWidgetView extends HabitWidgetView
 {
 
     private final View dataView;
 
-    private TextView title;
+    private LinearLayout legend;
+
+    private List<Habit> habits;
 
     public GraphWidgetView(Context context, View dataView)
     {
@@ -45,9 +52,18 @@ public class GraphWidgetView extends HabitWidgetView
         return dataView;
     }
 
-    public void setTitle(String text)
-    {
-        title.setText(text);
+    public void setHabits(List<Habit> habits) {
+        for (Habit habit : habits) {
+            TextView t = new TextView(getContext());
+            if (habits.size() == 1) {
+                t.setTextColor(Color.WHITE);
+            } else {
+                t.setTextColor(PaletteUtils.getColor(getContext(), habit.getColor()));
+            }
+            t.setPadding(7, 0, 7, 0);
+            t.setText(habit.getName());
+            legend.addView(t);
+        }
     }
 
     @Override
@@ -67,7 +83,6 @@ public class GraphWidgetView extends HabitWidgetView
         ViewGroup innerFrame = (ViewGroup) findViewById(R.id.innerFrame);
         innerFrame.addView(dataView);
 
-        title = (TextView) findViewById(R.id.title);
-        title.setVisibility(VISIBLE);
+        legend = (LinearLayout) findViewById(R.id.legend);
     }
 }

--- a/uhabits-android/src/main/res/layout/widget_graph.xml
+++ b/uhabits-android/src/main/res/layout/widget_graph.xml
@@ -38,12 +38,12 @@
         android:paddingBottom="4dp"
         tools:ignore="UselessParent">
 
-        <TextView
-            android:id="@+id/title"
+        <LinearLayout
+            android:id="@+id/legend"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center"
-            android:textColor="@color/white"/>
+            android:orientation="horizontal"/>
 
     </LinearLayout>
 


### PR DESCRIPTION
This is a start at tackling one of the items in #51 
Displaying multiple habits on the same strength chart.

Now when creating a widget from several habits, if you choose "Habit
strength" as the type, then instead of stacking, they will be displayed
on the same chart.

It's a bit hacky, and needs cleaning up some, so I'm just looking for a high level review at the moment. If you think it's in the right direction I can carry on. Otherwise I'd be interested to hear how you would approach it.

Known issues:
* All references to Habit were removed from ScoreChart in a refactor, so maybe we'll want to do this differently, as I've just added them back to get it working quickly.
* The legend on the graph doesn't wrap around.
* The legend text can be hard to read depending on the colors of your habits. It might be a better idea to automatically assign colors to each habit just for this chart, this would also ensure the lines are all different colors, which is a current issue. Or maybe change the background for it or something, I'm no good at UI design...
* The way I've used ArrayLists everywhere feels a bit hacky.
* I broke the populateWithRandomData method for convenience.
* I also haven't touched or even ran the tests.

Screenshot:
<img width="356" alt="screen shot 2018-10-28 at 00 49 29" src="https://user-images.githubusercontent.com/692011/47610371-73807180-da4b-11e8-9208-92fa1fef3783.png">
