### PR TITLE
feat: Always hide archive/unarchive icon

### DIFF
--- a/uhabits-android/src/main/res/menu/list_habits_selection.xml
+++ b/uhabits-android/src/main/res/menu/list_habits_selection.xml
@@ -34,12 +34,12 @@
     <item
         android:id="@+id/action_archive_habit"
         android:title="@string/archive"
-        android:icon="?iconArchive" />
+        app:showAsAction="never" />
 
     <item
         android:id="@+id/action_unarchive_habit"
         android:title="@string/unarchive"
-        android:icon="?iconUnarchive"/>
+        app:showAsAction="never"/>
 
     <item
         android:id="@+id/action_delete"


### PR DESCRIPTION
  - Improves usability since the icons do not
    jump around when more than one habit is
    selected

References: #465