### PR TITLE
feat: Change order of calendar and history"

### DIFF
--- a/uhabits-android/build.gradle
+++ b/uhabits-android/build.gradle
@@ -108,7 +108,7 @@ dependencies {
     implementation "org.apmem.tools:layouts:1.10"
     implementation "com.google.code.gson:gson:2.7"
     implementation "com.google.code.findbugs:jsr305:3.0.2"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$KOTLIN_VERSION"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
 
     compileOnly "javax.annotation:jsr250-api:1.0"
     compileOnly "com.google.auto.factory:auto-factory:1.0-beta3"

--- a/uhabits-android/src/main/res/layout/show_habit_inner.xml
+++ b/uhabits-android/src/main/res/layout/show_habit_inner.xml
@@ -52,16 +52,16 @@
             style="@style/Card"
             android:gravity="center"/>
 
-        <org.isoron.uhabits.activities.habits.show.views.BarCard
-            android:id="@+id/barCard"
-            style="@style/Card"
-            android:gravity="center"/>
-
         <org.isoron.uhabits.activities.habits.show.views.HistoryCard
             android:id="@+id/historyCard"
             style="@style/Card"
             android:gravity="center"
             android:paddingBottom="0dp"/>
+
+        <org.isoron.uhabits.activities.habits.show.views.BarCard
+            android:id="@+id/barCard"
+            style="@style/Card"
+            android:gravity="center"/>
 
         <org.isoron.uhabits.activities.habits.show.views.StreakCard
             android:id="@+id/streakCard"


### PR DESCRIPTION
I think it would be better to change the order of the calendar and the history widget. That is because the user is more likely to find out on which days he completed the habit than how many times he did the habit in a certain month.

Also it would put the history and the best streak chart together which kinda belong together in my opinion.

What are your thoughts about this?