### PR TITLE
Fix background of popup elements in black theme

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/HistoryEditorDialog.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/HistoryEditorDialog.java
@@ -25,6 +25,7 @@ import android.os.*;
 import android.support.annotation.*;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.*;
+import android.support.v7.view.ContextThemeWrapper;
 import android.util.*;
 
 import org.isoron.uhabits.*;
@@ -34,6 +35,7 @@ import org.isoron.uhabits.core.tasks.*;
 import org.isoron.uhabits.utils.*;
 
 import static org.isoron.androidbase.utils.InterfaceUtils.*;
+import static org.isoron.uhabits.core.ui.ThemeSwitcher.THEME_LIGHT;
 
 public class HistoryEditorDialog extends AppCompatDialogFragment
     implements DialogInterface.OnClickListener, ModelObservable.Listener
@@ -60,6 +62,22 @@ public class HistoryEditorDialog extends AppCompatDialogFragment
     public void onClick(DialogInterface dialog, int which)
     {
         dismiss();
+    }
+
+    @Override
+    public int getTheme()
+    {
+        HabitsApplicationComponent component =
+                ((HabitsApplication) getContext().getApplicationContext()).getComponent();
+
+        if(component.getPreferences().getTheme() == THEME_LIGHT)
+            return R.style.DialogWithTitle;
+        else {
+            if (component.getPreferences().isPureBlackEnabled()) {
+                return R.style.BlackDialogWithTitle;
+            }
+            return R.style.DarkDialogWithTitle;
+        }
     }
 
     @NonNull
@@ -90,7 +108,7 @@ public class HistoryEditorDialog extends AppCompatDialogFragment
         historyChart.setPadding(padding, 0, padding, 0);
         historyChart.setIsEditable(true);
 
-        AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        AlertDialog.Builder builder = new AlertDialog.Builder(new ContextThemeWrapper(context, getTheme()));
         builder
             .setTitle(R.string.history)
             .setView(historyChart)

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/edit/EditHabitDialog.java
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/edit/EditHabitDialog.java
@@ -41,6 +41,7 @@ import org.isoron.uhabits.core.preferences.*;
 import butterknife.*;
 
 import static android.view.View.GONE;
+import static org.isoron.uhabits.core.ui.ThemeSwitcher.THEME_DARK;
 import static org.isoron.uhabits.core.ui.ThemeSwitcher.THEME_LIGHT;
 
 public class EditHabitDialog extends AppCompatDialogFragment
@@ -83,8 +84,12 @@ public class EditHabitDialog extends AppCompatDialogFragment
 
         if(component.getPreferences().getTheme() == THEME_LIGHT)
             return R.style.DialogWithTitle;
-        else
+        else {
+            if (component.getPreferences().isPureBlackEnabled()) {
+                return R.style.BlackDialogWithTitle;
+            }
             return R.style.DarkDialogWithTitle;
+        }
     }
 
     @Override

--- a/uhabits-android/src/main/res/values/styles.xml
+++ b/uhabits-android/src/main/res/values/styles.xml
@@ -139,6 +139,8 @@
 
         <item name="lowContrastTextColor">@color/grey_900</item>
         <item name="highContrastReverseTextColor">@color/black</item>
+
+        <item name="toolbarPopupTheme">@style/BlackToolbarPopupTheme</item>
     </style>
 
     <style name="TransparentWidgetTheme" parent="AppBaseThemeDark">
@@ -257,6 +259,16 @@
     <style name="DarkDialogWithTitle"
            parent="@style/Theme.AppCompat.Dialog">
         <item name="windowNoTitle">false</item>
+    </style>
+
+    <style name="BlackDialogWithTitle"
+           parent="@style/DarkDialogWithTitle">
+        <item name="android:colorBackground">#181818</item>
+        <item name="android:background">#181818</item>
+    </style>
+    
+    <style name="BlackToolbarPopupTheme" parent="@style/ThemeOverlay.AppCompat.Light">
+        <item name="android:colorBackground">#181818</item>
     </style>
 
     <style name="ScrollableRecyclerViewStyle" parent="android:Widget">


### PR DESCRIPTION
Popup elements in the pure black mode use the default theming of the dark mode which looks a bit odd because it's too light. So I suppose we should change the color accordingly.