### PR TITLE
Changed habit type selection to dropdown instead of popup message

### DIFF
--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsMenu.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsMenu.kt
@@ -73,6 +73,16 @@ class ListHabitsMenu @Inject constructor(
                 return true
             }
 
+            R.id.actionCreateBooleanHabit -> {
+                behavior.onCreateBooleanHabit()
+                return true
+            }
+
+            R.id.actionCreateNumeralHabit -> {
+                behavior.onCreateNumericalHabit()
+                return true
+            }
+
             R.id.actionFAQ -> {
                 behavior.onViewFAQ()
                 return true

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsMenu.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsMenu.kt
@@ -46,30 +46,15 @@ class ListHabitsMenu @Inject constructor(
         hideArchivedItem.isChecked = !preferences.showArchived
         hideCompletedItem.isChecked = !preferences.showCompleted
 
-
         topBarMenu = menu
-        //the habit creation menu should be disabled when numeric habits are also disabled
-        if (!preferences.isNumericalHabitsFeatureEnabled) {
-            setCreateHabitMenuEnabled(false, menu)
-        }
         //let the class add itself as listener
         preferences.addListener(this)
-    }
-
-    override fun onNumericalHabitsFeatureChanged() {
-        if(topBarMenu==null){return}
-        setCreateHabitMenuEnabled(preferences.isNumericalHabitsFeatureEnabled, topBarMenu)
     }
 
     override fun onItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             R.id.actionToggleNightMode -> {
                 behavior.onToggleNightMode()
-                return true
-            }
-
-            R.id.actionAdd -> {
-                behavior.onCreateHabit()
                 return true
             }
 
@@ -138,6 +123,7 @@ class ListHabitsMenu @Inject constructor(
      * @param enabled whether the create habit menu should be enabled or disabled
      * @param menu a reference to the menu on which should be enabled or disabled
      */
+    @Deprecated(message = "This function was used to enable/disable the habit creation drop down menu, but since the feature is mostly implemented this is no longer necessary.")
     fun setCreateHabitMenuEnabled(enabled: Boolean, menu: Menu) {
         val habitCreationMenu = menu.findItem(R.id.actionAdd).subMenu
         for (itemIndex: Int in 0 until habitCreationMenu.size()) {

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsMenu.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsMenu.kt
@@ -33,7 +33,7 @@ class ListHabitsMenu @Inject constructor(
         private val preferences: Preferences,
         private val themeSwitcher: ThemeSwitcher,
         private val behavior: ListHabitsMenuBehavior
-) : BaseMenu(activity), Preferences.Listener {
+) : BaseMenu(activity){
 
     override fun onCreate(menu: Menu) {
         val nightModeItem = menu.findItem(R.id.actionToggleNightMode)

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsMenu.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsMenu.kt
@@ -35,8 +35,6 @@ class ListHabitsMenu @Inject constructor(
         private val behavior: ListHabitsMenuBehavior
 ) : BaseMenu(activity), Preferences.Listener {
 
-    private lateinit var topBarMenu: Menu
-
     override fun onCreate(menu: Menu) {
         val nightModeItem = menu.findItem(R.id.actionToggleNightMode)
         val hideArchivedItem = menu.findItem(R.id.actionHideArchived)
@@ -45,10 +43,6 @@ class ListHabitsMenu @Inject constructor(
         nightModeItem.isChecked = themeSwitcher.isNightMode
         hideArchivedItem.isChecked = !preferences.showArchived
         hideCompletedItem.isChecked = !preferences.showCompleted
-
-        topBarMenu = menu
-        //let the class add itself as listener
-        preferences.addListener(this)
     }
 
     override fun onItemSelected(item: MenuItem): Boolean {
@@ -116,20 +110,6 @@ class ListHabitsMenu @Inject constructor(
             }
 
             else -> return false
-        }
-    }
-
-    /**
-     * @param enabled whether the create habit menu should be enabled or disabled
-     * @param menu a reference to the menu on which should be enabled or disabled
-     */
-    @Deprecated(message = "This function was used to enable/disable the habit creation drop down menu, but since the feature is mostly implemented this is no longer necessary.")
-    fun setCreateHabitMenuEnabled(enabled: Boolean, menu: Menu) {
-        val habitCreationMenu = menu.findItem(R.id.actionAdd).subMenu
-        for (itemIndex: Int in 0 until habitCreationMenu.size()) {
-            val menuItem = habitCreationMenu.getItem(itemIndex)
-            menuItem.isEnabled = enabled
-            menuItem.isVisible = enabled
         }
     }
 

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsScreen.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsScreen.kt
@@ -137,8 +137,13 @@ class ListHabitsScreen
         activity.startActivity(intent)
     }
 
-    fun showCreateBooleanHabitScreen() {
+    override fun showCreateBooleanHabitScreen() {
         val dialog = editHabitDialogFactory.createBoolean()
+        activity.showDialog(dialog, "editHabit")
+    }
+
+    override fun showCreateNumericalHabitScreen() {
+        val dialog = editHabitDialogFactory.createNumerical()
         activity.showDialog(dialog, "editHabit")
     }
 
@@ -234,11 +239,6 @@ class ListHabitsScreen
             is UnarchiveHabitsCommand -> return R.string.toast_habit_unarchived
             else -> return null
         }
-    }
-
-    private fun showCreateNumericalHabitScreen() {
-        val dialog = editHabitDialogFactory.createNumerical()
-        activity.showDialog(dialog, "editHabit")
     }
 
     private fun onImportData(file: File, onFinished: () -> Unit) {

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsScreen.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsScreen.kt
@@ -147,23 +147,6 @@ class ListHabitsScreen
         activity.showDialog(dialog, "editHabit")
     }
 
-    override fun showCreateHabitScreen() {
-        if (!preferences.isNumericalHabitsFeatureEnabled) {
-            showCreateBooleanHabitScreen()
-            return
-        }
-
-        val dialog = AlertDialog.Builder(activity)
-                .setTitle("Type of habit")
-                .setItems(R.array.habitTypes) { _, which ->
-                    if (which == 0) showCreateBooleanHabitScreen()
-                    else showCreateNumericalHabitScreen()
-                }
-                .create()
-
-        dialog.show()
-    }
-
     override fun showDeleteConfirmationScreen(callback: OnConfirmedCallback) {
         activity.showDialog(confirmDeleteDialogFactory.create(callback))
     }

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/preferences/SharedPreferencesStorage.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/preferences/SharedPreferencesStorage.kt
@@ -89,6 +89,8 @@ class SharedPreferencesStorage
                 preferences.setNotificationsLed(getBoolean(key, false))
             "pref_feature_sync" ->
                 preferences.isSyncEnabled = getBoolean(key, false)
+            "pref_feature_numerical_habits" ->
+                preferences.isNumericalHabitsFeatureEnabled = getBoolean(key, false)
         }
         sharedPreferences.registerOnSharedPreferenceChangeListener(this)
     }

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/preferences/SharedPreferencesStorage.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/preferences/SharedPreferencesStorage.kt
@@ -89,8 +89,6 @@ class SharedPreferencesStorage
                 preferences.setNotificationsLed(getBoolean(key, false))
             "pref_feature_sync" ->
                 preferences.isSyncEnabled = getBoolean(key, false)
-            "pref_feature_numerical_habits" ->
-                preferences.isNumericalHabitsFeatureEnabled = getBoolean(key, false)
         }
         sharedPreferences.registerOnSharedPreferenceChangeListener(this)
     }

--- a/android/uhabits-android/src/main/res/menu/list_habits.xml
+++ b/android/uhabits-android/src/main/res/menu/list_habits.xml
@@ -32,12 +32,12 @@
             <item
                 android:id="@+id/actionCreateBooleanHabit"
                 android:enabled="true"
-                android:title="@string/yes_or_no" />
+                android:title="@string/yes_or_no"/>
 
             <item
                 android:id="@+id/actionCreateNumeralHabit"
                 android:enabled="true"
-                android:title="@string/number" />
+                android:title="@string/number"/>
         </menu>
     </item>
 
@@ -51,31 +51,31 @@
                 android:id="@+id/actionHideArchived"
                 android:checkable="true"
                 android:enabled="true"
-                android:title="@string/hide_archived" />
+                android:title="@string/hide_archived"/>
 
             <item
                 android:id="@+id/actionHideCompleted"
                 android:checkable="true"
                 android:enabled="true"
-                android:title="@string/hide_completed" />
+                android:title="@string/hide_completed"/>
 
             <item android:title="@string/sort">
                 <menu>
                     <item
                         android:id="@+id/actionSortManual"
-                        android:title="@string/manually" />
+                        android:title="@string/manually"/>
 
                     <item
                         android:id="@+id/actionSortName"
-                        android:title="@string/by_name" />
+                        android:title="@string/by_name"/>
 
                     <item
                         android:id="@+id/actionSortColor"
-                        android:title="@string/by_color" />
+                        android:title="@string/by_color"/>
 
                     <item
                         android:id="@+id/actionSortScore"
-                        android:title="@string/by_score" />
+                        android:title="@string/by_score"/>
                 </menu>
             </item>
         </menu>
@@ -87,23 +87,23 @@
         android:enabled="true"
         android:orderInCategory="50"
         android:title="@string/night_mode"
-        app:showAsAction="never" />
+        app:showAsAction="never"/>
 
     <item
         android:id="@+id/actionSettings"
         android:orderInCategory="100"
         android:title="@string/action_settings"
-        app:showAsAction="never" />
+        app:showAsAction="never"/>
 
     <item
         android:id="@+id/actionFAQ"
         android:orderInCategory="100"
         android:title="@string/help"
-        app:showAsAction="never" />
+        app:showAsAction="never"/>
 
     <item
         android:id="@+id/actionAbout"
         android:orderInCategory="100"
         android:title="@string/about"
-        app:showAsAction="never" />
+        app:showAsAction="never"/>
 </menu>

--- a/android/uhabits-android/src/main/res/menu/list_habits.xml
+++ b/android/uhabits-android/src/main/res/menu/list_habits.xml
@@ -18,15 +18,28 @@
   -->
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:app="http://schemas.android.com/apk/res-auto"
-      xmlns:tools="http://schemas.android.com/tools"
-      tools:context=".MainActivity">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".MainActivity">
 
     <item
         android:id="@+id/actionAdd"
         android:icon="?iconAdd"
         android:title="@string/add_habit"
-        app:showAsAction="always"/>
+        app:showAsAction="always">
+
+        <menu android:id="@+id/createHabitMenu">
+            <item
+                android:id="@+id/actionCreateBooleanHabit"
+                android:enabled="true"
+                android:title="@string/yes_or_no" />
+
+            <item
+                android:id="@+id/actionCreateNumeralHabit"
+                android:enabled="true"
+                android:title="@string/number" />
+        </menu>
+    </item>
 
     <item
         android:id="@+id/action_filter"
@@ -38,31 +51,31 @@
                 android:id="@+id/actionHideArchived"
                 android:checkable="true"
                 android:enabled="true"
-                android:title="@string/hide_archived"/>
+                android:title="@string/hide_archived" />
 
             <item
                 android:id="@+id/actionHideCompleted"
                 android:checkable="true"
                 android:enabled="true"
-                android:title="@string/hide_completed"/>
+                android:title="@string/hide_completed" />
 
             <item android:title="@string/sort">
                 <menu>
                     <item
                         android:id="@+id/actionSortManual"
-                        android:title="@string/manually"/>
+                        android:title="@string/manually" />
 
                     <item
                         android:id="@+id/actionSortName"
-                        android:title="@string/by_name"/>
+                        android:title="@string/by_name" />
 
                     <item
                         android:id="@+id/actionSortColor"
-                        android:title="@string/by_color"/>
+                        android:title="@string/by_color" />
 
                     <item
                         android:id="@+id/actionSortScore"
-                        android:title="@string/by_score"/>
+                        android:title="@string/by_score" />
                 </menu>
             </item>
         </menu>
@@ -74,23 +87,23 @@
         android:enabled="true"
         android:orderInCategory="50"
         android:title="@string/night_mode"
-        app:showAsAction="never"/>
+        app:showAsAction="never" />
 
     <item
         android:id="@+id/actionSettings"
         android:orderInCategory="100"
         android:title="@string/action_settings"
-        app:showAsAction="never"/>
+        app:showAsAction="never" />
 
     <item
         android:id="@+id/actionFAQ"
         android:orderInCategory="100"
         android:title="@string/help"
-        app:showAsAction="never"/>
+        app:showAsAction="never" />
 
     <item
         android:id="@+id/actionAbout"
         android:orderInCategory="100"
         android:title="@string/about"
-        app:showAsAction="never"/>
+        app:showAsAction="never" />
 </menu>

--- a/android/uhabits-android/src/main/res/values/strings.xml
+++ b/android/uhabits-android/src/main/res/values/strings.xml
@@ -184,6 +184,10 @@
 
     <string name="total">Total</string>
 
+    <!-- Different types of habits -->
+    <string name="yes_or_no">Yes or No</string>
+    <string name="number">Number</string>
+
     <!-- Middle part of the sentence '1 time in xx days' -->
     <string name="time_every">time in</string>
 

--- a/android/uhabits-android/src/main/res/xml/preferences.xml
+++ b/android/uhabits-android/src/main/res/xml/preferences.xml
@@ -155,11 +155,6 @@
 
         <CheckBoxPreference
             android:defaultValue="false"
-            android:key="pref_feature_numerical_habits"
-            android:title="Enable numerical habits"/>
-
-        <CheckBoxPreference
-            android:defaultValue="false"
             android:key="pref_feature_sync"
             android:title="Enable cloud sync"/>
 

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/preferences/Preferences.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/preferences/Preferences.java
@@ -224,17 +224,6 @@ public class Preferences
         storage.putBoolean("pref_first_run", isFirstRun);
     }
 
-    public boolean isNumericalHabitsFeatureEnabled()
-    {
-        return storage.getBoolean("pref_feature_numerical_habits", false);
-    }
-
-    public void setNumericalHabitsFeatureEnabled(boolean enabled)
-    {
-        storage.putBoolean("pref_feature_numerical_habits", enabled);
-        for (Listener l : listeners) l.onNumericalHabitsFeatureChanged();
-    }
-
     public boolean isPureBlackEnabled()
     {
         return storage.getBoolean("pref_pure_black", false);

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/preferences/Preferences.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/preferences/Preferences.java
@@ -336,10 +336,6 @@ public class Preferences
         default void onSyncFeatureChanged()
         {
         }
-
-        default void onNumericalHabitsFeatureChanged()
-        {
-        }
     }
 
     public interface Storage

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/preferences/Preferences.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/preferences/Preferences.java
@@ -232,6 +232,7 @@ public class Preferences
     public void setNumericalHabitsFeatureEnabled(boolean enabled)
     {
         storage.putBoolean("pref_feature_numerical_habits", enabled);
+        for (Listener l : listeners) l.onNumericalHabitsFeatureChanged();
     }
 
     public boolean isPureBlackEnabled()
@@ -344,6 +345,10 @@ public class Preferences
         }
 
         default void onSyncFeatureChanged()
+        {
+        }
+
+        default void onNumericalHabitsFeatureChanged()
         {
         }
     }

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsMenuBehavior.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsMenuBehavior.java
@@ -74,6 +74,16 @@ public class ListHabitsMenuBehavior
         }
     }
 
+    public void onCreateBooleanHabit()
+    {
+        screen.showCreateBooleanHabitScreen();
+    }
+
+    public void onCreateNumericalHabit()
+    {
+        screen.showCreateNumericalHabitScreen();
+    }
+
     public void onViewFAQ()
     {
         screen.showFAQScreen();
@@ -154,6 +164,10 @@ public class ListHabitsMenuBehavior
         void showAboutScreen();
 
         void showCreateHabitScreen();
+
+        void showCreateBooleanHabitScreen();
+
+        void showCreateNumericalHabitScreen();
 
         void showFAQScreen();
 

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsMenuBehavior.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsMenuBehavior.java
@@ -61,9 +61,17 @@ public class ListHabitsMenuBehavior
         updateAdapterFilter();
     }
 
+    /**
+     * This function is called when a new habit should be created. (A dialog will be created)
+     * When only a single type of habit type exists (e.g. the numeral habits feature is disabled) a menu is spawned directly.
+     * If this is not the case however, a dropdown menu is shown.
+     */
     public void onCreateHabit()
     {
-        screen.showCreateHabitScreen();
+        if(!preferences.isNumericalHabitsFeatureEnabled())
+        {
+            screen.showCreateHabitScreen();
+        }
     }
 
     public void onViewFAQ()

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsMenuBehavior.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsMenuBehavior.java
@@ -61,19 +61,6 @@ public class ListHabitsMenuBehavior
         updateAdapterFilter();
     }
 
-    /**
-     * This function is called when a new habit should be created. (A dialog will be created)
-     * When only a single type of habit type exists (e.g. the numeral habits feature is disabled) a menu is spawned directly.
-     * If this is not the case however, a dropdown menu is shown.
-     */
-    public void onCreateHabit()
-    {
-        if(!preferences.isNumericalHabitsFeatureEnabled())
-        {
-            screen.showCreateHabitScreen();
-        }
-    }
-
     public void onCreateBooleanHabit()
     {
         screen.showCreateBooleanHabitScreen();
@@ -162,8 +149,6 @@ public class ListHabitsMenuBehavior
         void applyTheme();
 
         void showAboutScreen();
-
-        void showCreateHabitScreen();
 
         void showCreateBooleanHabitScreen();
 

--- a/android/uhabits-core/src/test/java/org/isoron/uhabits/core/preferences/PreferencesTest.java
+++ b/android/uhabits-core/src/test/java/org/isoron/uhabits/core/preferences/PreferencesTest.java
@@ -197,14 +197,6 @@ public class PreferencesTest extends BaseUnitTest
     }
 
     @Test
-    public void testNumericalHabits() throws Exception
-    {
-        assertFalse(prefs.isNumericalHabitsFeatureEnabled());
-        prefs.setNumericalHabitsFeatureEnabled(true);
-        assertTrue(prefs.isNumericalHabitsFeatureEnabled());
-    }
-
-    @Test
     public void testDeveloper() throws Exception
     {
         assertFalse(prefs.isDeveloper());


### PR DESCRIPTION
Hi there!

I've been working on issue #42 and have a proposal to ' Improve [the] dialog for selecting what kind of habit to create'.

I have done this by changing the old popup message to a dropdown menu.
If this change is accepted I'll first remove/cleanup the old popup message code.
I've also done some extra work to make sure the checkbox to enable/disable numeric habits in settings works without restarting the app.

Right now I'm asking for some feedback on my code, since I'm not that familiar with this kind of android development I had to figure out a Kotlin, how dagger works and I had to take a good look at the design patterns used. I'm not sure I've used them correctly. In my code I've made ListHabitsMenu an Preferences.Listener. This way it can enable/disable the dropdown menu when this feature is enabled/disabled. This way all UI can be in the original list_habits.xml file and once the NumericalHabitsFeatureEnabled setting becomes deprecated it's easily removed, resulting in cleaner code. The problem that I have with this solution is that it's not very nice that ListHabitsMenu knows and does as much as it's doing. Choosing if the menu should be shown or not should be in the uhabits-core. I have no idea how to do that however. Because dagger uses a directed acyclic graph I can't give the behavior a reference to the menu because the menu already has a ListHabitsMenuBehavior.