### PR TITLE
Preserve selections when reopening EditSettingActivity

### DIFF
--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/automation/EditSettingActivity.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/automation/EditSettingActivity.kt
@@ -35,8 +35,10 @@ class EditSettingActivity : BaseActivity() {
                         .setCompletedAllowed(true)
                         .build())
 
+        val args = SettingUtils.parseIntent(this.intent, habits)
+
         val controller = EditSettingController(this)
-        val rootView = EditSettingRootView(this, habits, controller)
+        val rootView = EditSettingRootView(this, habits, controller, args)
         val screen = BaseScreen(this)
         screen.setRootView(rootView)
         setScreen(screen)

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/automation/EditSettingRootView.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/automation/EditSettingRootView.kt
@@ -34,7 +34,8 @@ import java.util.*
 class EditSettingRootView(
         context: Context,
         private val habitList: HabitList,
-        private val controller: EditSettingController
+        private val controller: EditSettingController,
+        args: SettingUtils.Arguments?
 ) : BaseRootView(context) {
 
     @BindView(R.id.toolbar)
@@ -50,6 +51,11 @@ class EditSettingRootView(
         addView(inflate(getContext(), R.layout.automation, null))
         ButterKnife.bind(this)
         populateHabitSpinner()
+
+        args?.let {
+            habitSpinner.setSelection(habitList.indexOf(it.habit))
+            actionSpinner.setSelection(it.action)
+        }
     }
 
     override fun getToolbar(): Toolbar {

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/automation/FireSettingReceiver.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/automation/FireSettingReceiver.kt
@@ -44,7 +44,7 @@ class FireSettingReceiver : BroadcastReceiver() {
                 .habitsApplicationComponent(app.component)
                 .build()
         allHabits = app.component.habitList
-        val args = parseIntent(intent) ?: return
+        val args = SettingUtils.parseIntent(intent, allHabits) ?: return
         val timestamp = DateUtils.getToday()
         val controller = component.widgetController
 
@@ -55,19 +55,9 @@ class FireSettingReceiver : BroadcastReceiver() {
         }
     }
 
-    private fun parseIntent(intent: Intent): Arguments? {
-        val bundle = intent.getBundleExtra(EXTRA_BUNDLE) ?: return null
-        val action = bundle.getInt("action")
-        if (action < 0 || action > 2) return null
-        val habit = allHabits.getById(bundle.getLong("habit")) ?: return null
-        return Arguments(action, habit)
-    }
-
     @ReceiverScope
     @Component(dependencies = arrayOf(HabitsApplicationComponent::class))
     internal interface ReceiverComponent {
         val widgetController: WidgetBehavior
     }
-
-    private class Arguments(var action: Int, var habit: Habit)
 }

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/automation/SettingUtils.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/automation/SettingUtils.kt
@@ -1,0 +1,18 @@
+package org.isoron.uhabits.automation
+
+import android.content.Intent
+import org.isoron.uhabits.core.models.Habit
+import org.isoron.uhabits.core.models.HabitList
+
+object SettingUtils {
+    @JvmStatic
+    fun parseIntent(intent: Intent, allHabits: HabitList): Arguments? {
+        val bundle = intent.getBundleExtra(EXTRA_BUNDLE) ?: return null
+        val action = bundle.getInt("action")
+        if (action < 0 || action > 2) return null
+        val habit = allHabits.getById(bundle.getLong("habit")) ?: return null
+        return Arguments(action, habit)
+    }
+
+    class Arguments(var action: Int, var habit: Habit)
+}


### PR DESCRIPTION
I noticed that when I opened Tasker to edit my settings for the Loop plugin, the spinners weren't set to the habit/action I selected previously. This fixes that.

> The host may also pass the Bundle back to the Activity in the future, if the user wishes to edit the plug-in's configuration.

Source: https://www.twofortyfouram.com/developer/