### PR TITLE
Capitalize sentences on dialogFormInputMultiline

### DIFF
--- a/android/uhabits-android/src/main/res/values/styles_dialog.xml
+++ b/android/uhabits-android/src/main/res/values/styles_dialog.xml
@@ -24,7 +24,7 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:ems">10</item>
-        <item name="android:inputType">textMultiLine</item>
+        <item name="android:inputType">textCapSentences|textMultiLine</item>
     </style>
 
     <style name="dialogFormInputColor">


### PR DESCRIPTION
The Question field had a capitalized hint but when you start typing it wasn't capitalized by default, which was a little confusing. This PR simply adds capitalization to sentences in the description field 😄 

![Screenshot_1577471841](https://user-images.githubusercontent.com/9154202/71528481-46bd2980-289d-11ea-9566-2aa4f62d6bb7.png)
