### PR TITLE
Fix #534. issue where weekly picker dialog isn't being restored on rotation

### DIFF
--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/WeekdayPickerDialog.java
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/WeekdayPickerDialog.java
@@ -19,19 +19,19 @@
 
 package org.isoron.uhabits.activities.common.dialogs;
 
-import android.app.*;
-import android.content.*;
-import android.os.*;
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AlertDialog;
-import android.support.v7.app.*;
+import android.support.v7.app.AppCompatDialogFragment;
 
-import org.isoron.uhabits.*;
-import org.isoron.uhabits.core.models.*;
-import org.isoron.uhabits.core.utils.*;
+import org.isoron.uhabits.R;
+import org.isoron.uhabits.core.models.WeekdayList;
+import org.isoron.uhabits.core.utils.DateUtils;
 
-import java.util.*;
+import java.util.Calendar;
 
 /**
  * Dialog that allows the user to pick one or more days of the week.

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/WeekdayPickerDialog.java
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/WeekdayPickerDialog.java
@@ -22,6 +22,8 @@ package org.isoron.uhabits.activities.common.dialogs;
 import android.app.*;
 import android.content.*;
 import android.os.*;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.*;
 
@@ -38,6 +40,7 @@ public class WeekdayPickerDialog extends AppCompatDialogFragment implements
                                                                  DialogInterface.OnMultiChoiceClickListener,
                                                                  DialogInterface.OnClickListener
 {
+    private static final String KEY_SELECTED_DAYS = "selectedDays";
     private boolean[] selectedDays;
 
     private OnWeekdaysPickedListener listener;
@@ -46,6 +49,21 @@ public class WeekdayPickerDialog extends AppCompatDialogFragment implements
     public void onClick(DialogInterface dialog, int which, boolean isChecked)
     {
         selectedDays[which] = isChecked;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if(savedInstanceState != null){
+            selectedDays = savedInstanceState.getBooleanArray(KEY_SELECTED_DAYS);
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putBooleanArray(KEY_SELECTED_DAYS, selectedDays);
     }
 
     @Override

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/edit/EditHabitDialog.java
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/edit/EditHabitDialog.java
@@ -23,8 +23,10 @@ import android.app.Dialog;
 import android.content.*;
 import android.os.*;
 import android.support.annotation.*;
+import android.support.v4.app.Fragment;
 import android.support.v7.app.*;
 import android.text.format.*;
+import android.util.Log;
 import android.view.*;
 
 import com.android.datetimepicker.time.*;
@@ -47,6 +49,8 @@ public class EditHabitDialog extends AppCompatDialogFragment
     public static final String BUNDLE_HABIT_ID = "habitId";
 
     public static final String BUNDLE_HABIT_TYPE = "habitType";
+    public static final String EDIT_HABIT_TAG = "editHabit";
+    private static final String WEEKDAY_PICKER_TAG = "weekdayPicker";
 
     protected Habit originalHabit;
 
@@ -108,6 +112,8 @@ public class EditHabitDialog extends AppCompatDialogFragment
         populateForm();
         setupReminderController();
         setupNameController();
+
+        restoreChildFragmentListeners();
 
         return view;
     }
@@ -268,8 +274,21 @@ public class EditHabitDialog extends AppCompatDialogFragment
                 WeekdayPickerDialog dialog = new WeekdayPickerDialog();
                 dialog.setListener(reminderPanel);
                 dialog.setSelectedDays(currentDays);
-                dialog.show(getFragmentManager(), "weekdayPicker");
+                dialog.show(getChildFragmentManager(), WEEKDAY_PICKER_TAG);
             }
         });
+    }
+
+    /**
+     * Used to restore any child fragment listeners on rotation/config change.
+     *
+     * Can possibly be refactored to use ViewModel/
+     */
+    private void restoreChildFragmentListeners() {
+        final WeekdayPickerDialog weekdayPickerDialog =
+                (WeekdayPickerDialog) getChildFragmentManager().findFragmentByTag(WEEKDAY_PICKER_TAG);
+        if(weekdayPickerDialog != null) {
+            weekdayPickerDialog.setListener(reminderPanel);
+        }
     }
 }

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/edit/EditHabitDialog.java
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/edit/EditHabitDialog.java
@@ -64,7 +64,6 @@ public class EditHabitDialog extends AppCompatDialogFragment
     public static final String BUNDLE_HABIT_ID = "habitId";
 
     public static final String BUNDLE_HABIT_TYPE = "habitType";
-    public static final String EDIT_HABIT_TAG = "editHabit";
     private static final String WEEKDAY_PICKER_TAG = "weekdayPicker";
 
     protected Habit originalHabit;

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/edit/EditHabitDialog.java
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/edit/EditHabitDialog.java
@@ -20,27 +20,42 @@
 package org.isoron.uhabits.activities.habits.edit;
 
 import android.app.Dialog;
-import android.content.*;
-import android.os.*;
-import android.support.annotation.*;
-import android.support.v4.app.Fragment;
-import android.support.v7.app.*;
-import android.text.format.*;
-import android.util.Log;
-import android.view.*;
+import android.content.Context;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatDialogFragment;
+import android.text.format.DateFormat;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowManager;
 
-import com.android.datetimepicker.time.*;
+import com.android.datetimepicker.time.TimePickerDialog;
 
-import org.isoron.uhabits.*;
+import org.isoron.uhabits.HabitsApplication;
+import org.isoron.uhabits.HabitsApplicationComponent;
 import org.isoron.uhabits.R;
-import org.isoron.uhabits.activities.*;
-import org.isoron.uhabits.activities.common.dialogs.*;
-import org.isoron.uhabits.activities.habits.edit.views.*;
-import org.isoron.uhabits.core.commands.*;
-import org.isoron.uhabits.core.models.*;
-import org.isoron.uhabits.core.preferences.*;
+import org.isoron.uhabits.activities.HabitsActivity;
+import org.isoron.uhabits.activities.common.dialogs.ColorPickerDialog;
+import org.isoron.uhabits.activities.common.dialogs.ColorPickerDialogFactory;
+import org.isoron.uhabits.activities.common.dialogs.WeekdayPickerDialog;
+import org.isoron.uhabits.activities.habits.edit.views.FrequencyPanel;
+import org.isoron.uhabits.activities.habits.edit.views.NameDescriptionPanel;
+import org.isoron.uhabits.activities.habits.edit.views.ReminderPanel;
+import org.isoron.uhabits.activities.habits.edit.views.TargetPanel;
+import org.isoron.uhabits.core.commands.CommandRunner;
+import org.isoron.uhabits.core.models.Frequency;
+import org.isoron.uhabits.core.models.Habit;
+import org.isoron.uhabits.core.models.HabitList;
+import org.isoron.uhabits.core.models.ModelFactory;
+import org.isoron.uhabits.core.models.WeekdayList;
+import org.isoron.uhabits.core.preferences.Preferences;
 
-import butterknife.*;
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
 
 import static android.view.View.GONE;
 


### PR DESCRIPTION
Fix #534.

**Changes**

- Implement ```onSaveinstanceState``` in WeekdayPickerDialog.java and save state
- Implement ```onCreate``` in WeekdayPickerDialog.java and restore state
- Changes to ```EditHabitDialog.java```
  - We also need to restore the listener in ```WeekdayPickerDialog```. Best way I can think of doing it is to restore it via ```EditHabitDialog``` when it's recreated upon rotation.
