### PR TITLE
Swipe to dismiss a habit for the day

### DIFF
--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsActivity.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsActivity.kt
@@ -52,7 +52,7 @@ class ListHabitsActivity : HabitsActivity() {
 
     override fun onPause() {
         midnightTimer.onPause()
-        screen.onDettached()
+        screen.onDetached()
         adapter.cancelRefresh()
         super.onPause()
     }

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsScreen.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsScreen.kt
@@ -86,7 +86,7 @@ class ListHabitsScreen
         commandRunner.addListener(this)
     }
 
-    fun onDettached() {
+    fun onDetached() {
         commandRunner.removeListener(this)
     }
 

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsScreen.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsScreen.kt
@@ -184,6 +184,7 @@ class ListHabitsScreen
                         DATABASE_REPAIRED -> R.string.database_repaired
                         COULD_NOT_GENERATE_BUG_REPORT -> R.string.bug_report_failed
                         FILE_NOT_RECOGNIZED -> R.string.file_not_recognized
+                        HABIT_DISMISSED -> R.string.toast_habit_dismissed
                     })
     }
 

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/HabitCardListAdapter.java
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/HabitCardListAdapter.java
@@ -288,6 +288,11 @@ public class HabitCardListAdapter
         cache.reorder(from, to);
     }
 
+    public void dismiss(int position)
+    {
+        cache.dismiss(position);
+    }
+
     @Override
     public void refresh()
     {

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/HabitCardListController.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/HabitCardListController.kt
@@ -49,6 +49,7 @@ class HabitCardListController @Inject constructor(
 
     override fun onSwiped(position: Int, direction: Int) {
         adapter.dismiss(position)
+        behavior.onDismissedHabit(adapter.getItem(position))
     }
 
     override fun drop(from: Int, to: Int) {

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/HabitCardListController.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/HabitCardListController.kt
@@ -47,6 +47,10 @@ class HabitCardListController @Inject constructor(
         adapter.observable.addListener(this)
     }
 
+    override fun onSwiped(position: Int, direction: Int) {
+        adapter.dismiss(position)
+    }
+
     override fun drop(from: Int, to: Int) {
         if (from == to) return
         cancelSelection()

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/HabitCardListView.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/HabitCardListView.kt
@@ -129,6 +129,7 @@ class HabitCardListView(
         fun drop(from: Int, to: Int) {}
         fun onItemClick(pos: Int) {}
         fun onItemLongClick(pos: Int) {}
+        fun onSwiped(position: Int, direction: Int) {}
         fun startDrag(position: Int) {}
     }
 
@@ -164,9 +165,11 @@ class HabitCardListView(
 
         override fun onSwiped(viewHolder: RecyclerView.ViewHolder,
                               direction: Int) {
+            val position = viewHolder.adapterPosition
+            controller.get().onSwiped(position, direction)
         }
 
-        override fun isItemViewSwipeEnabled() = false
+        override fun isItemViewSwipeEnabled() = true
         override fun isLongPressDragEnabled() = false
     }
 }

--- a/android/uhabits-android/src/main/res/values/strings.xml
+++ b/android/uhabits-android/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="color_picker_default_title">Change color</string>
 
     <string name="toast_habit_created">Habit created</string>
+    <string name="toast_habit_dismissed">Habit dismissed</string>
     <string name="toast_habit_deleted">Habits deleted</string>
     <string name="toast_habit_restored">Habits restored</string>
     <string name="toast_nothing_to_undo">Nothing to undo</string>

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/models/Habit.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/models/Habit.java
@@ -23,6 +23,7 @@ import androidx.annotation.*;
 
 import org.apache.commons.lang3.builder.*;
 
+import java.time.LocalDate;
 import java.util.*;
 
 import javax.annotation.concurrent.*;
@@ -30,6 +31,7 @@ import javax.inject.*;
 
 import static org.isoron.uhabits.core.models.Checkmark.*;
 import static org.isoron.uhabits.core.utils.StringUtils.defaultToStringStyle;
+
 
 /**
  * The thing that the user wants to track.
@@ -65,6 +67,8 @@ public class Habit
 
     @NonNull
     private CheckmarkList checkmarks;
+
+    private LocalDate lastDismissed = LocalDate.MIN;
 
     private ModelObservable observable = new ModelObservable();
 
@@ -337,6 +341,17 @@ public class Habit
     public synchronized boolean isNumerical()
     {
         return data.type == NUMBER_HABIT;
+    }
+
+    public synchronized boolean isDismissedToday()
+    {
+        LocalDate today = LocalDate.now();
+        return lastDismissed.equals(today);
+    }
+
+    public synchronized void dismiss()
+    {
+        lastDismissed = LocalDate.now();
     }
 
     public HabitData getData()

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/models/HabitMatcher.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/models/HabitMatcher.java
@@ -61,6 +61,7 @@ public class HabitMatcher
         if (!isArchivedAllowed() && habit.isArchived()) return false;
         if (isReminderRequired() && !habit.hasReminder()) return false;
         if (!isCompletedAllowed() && habit.isCompletedToday()) return false;
+        if (habit.isDismissedToday()) return false;
         return true;
     }
 }

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/ui/screens/habits/list/HabitCardListCache.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/ui/screens/habits/list/HabitCardListCache.java
@@ -183,6 +183,9 @@ public class HabitCardListCache implements CommandRunner.Listener
     {
         Habit habit = data.habits.get(position);
         habit.dismiss();
+        allHabits.update(habit);
+        filteredHabits.update(habit);
+        refreshHabit(habit.id);
     }
 
     public synchronized void setCheckmarkCount(int checkmarkCount)

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/ui/screens/habits/list/HabitCardListCache.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/ui/screens/habits/list/HabitCardListCache.java
@@ -179,6 +179,12 @@ public class HabitCardListCache implements CommandRunner.Listener
         listener.onItemMoved(from, to);
     }
 
+    public synchronized void dismiss(int position)
+    {
+        Habit habit = data.habits.get(position);
+        habit.dismiss();
+    }
+
     public synchronized void setCheckmarkCount(int checkmarkCount)
     {
         this.checkmarkCount = checkmarkCount;

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsBehavior.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsBehavior.java
@@ -115,7 +115,7 @@ public class ListHabitsBehavior
 
     public void onDismissedHabit(Habit habit)
     {
-        screen.showMessage(Message.HABIT_DISMISSED);
+        taskRunner.execute(() -> screen.showMessage(Message.HABIT_DISMISSED));
     }
 
     public void onReorderHabit(@NonNull Habit from, @NonNull Habit to)

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsBehavior.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsBehavior.java
@@ -113,6 +113,11 @@ public class ListHabitsBehavior
         screen.showIntroScreen();
     }
 
+    public void onDismissedHabit(Habit habit)
+    {
+        screen.showMessage(Message.HABIT_DISMISSED);
+    }
+
     public void onReorderHabit(@NonNull Habit from, @NonNull Habit to)
     {
         taskRunner.execute(() -> habitList.reorder(from, to));
@@ -159,7 +164,7 @@ public class ListHabitsBehavior
     public enum Message
     {
         COULD_NOT_EXPORT, IMPORT_SUCCESSFUL, IMPORT_FAILED, DATABASE_REPAIRED,
-        COULD_NOT_GENERATE_BUG_REPORT, FILE_NOT_RECOGNIZED
+        COULD_NOT_GENERATE_BUG_REPORT, FILE_NOT_RECOGNIZED, HABIT_DISMISSED
     }
 
     public interface BugReporter


### PR DESCRIPTION
Fixes #272 

- [X] User can swipe a habit
- [X] Swiped habit is tagged as dismissed
- [X] Habit list hides dismissed habits
- [X] "Habit dismissed" popup on swipe (imitates 'Habit created')
- [ ] Persist the dismissal so dismissed habits don't return on app restart
- [ ] Add 'Hide dismissed' filter checkbox to show dismissed habits (default: true)
- [ ] Optional: Add 'dismissed' indication in the ShowHabit activity, and a way to un-dismiss
- [ ] Tests: 
 - isDismissedToday() false after midnight
 - visibility resets at midnight
 - dismissed habit filtered from HabitList (unless 'Hide dismissed' is unchecked)
 - other suggestions?