### PR TITLE
Reset habit strength graph scroll location when switching scale

### DIFF
--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/ScrollableChart.java
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/ScrollableChart.java
@@ -217,6 +217,13 @@ public abstract class ScrollableChart extends View
         scrollController = new ScrollController() {};
     }
 
+    public void reset()
+    {
+        scroller.setFinalX(0);
+        scroller.computeScrollOffset();
+        updateDataOffset();
+    }
+
     private void updateDataOffset()
     {
         int newDataOffset = scroller.getCurrX() / scrollerBucketSize;

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/views/ScoreCard.java
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/views/ScoreCard.java
@@ -153,6 +153,7 @@ public class ScoreCard extends HabitCard
             else scores = scoreList.groupBy(getTruncateField(bucketSize), firstWeekday);
 
             chart.setScores(scores);
+            chart.reset();
             chart.setBucketSize(bucketSize);
         }
 


### PR DESCRIPTION
This PR closes a bug in which the habit strength graph does not correctly reset after switching scale (days, weeks, months, quarters, etc.). It does this by making the following changes:

- Create `ScrollableChart.reset()` to set `x` coordinate of scroller
- Call `reset()` from `doInBackground()` in `ScoreCard` to reset scroll location

Closes #575