### PR TITLE
Only save numerical habit features if the habit is numerical

### DIFF
--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/edit/EditHabitActivity.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/edit/EditHabitActivity.kt
@@ -214,9 +214,11 @@ class EditHabitActivity : AppCompatActivity() {
             habit.setReminder(Reminder(reminderHour, reminderMin, reminderDays))
         }
         habit.frequency = Frequency(freqNum, freqDen)
-        habit.targetValue = targetInput.text.toString().toDouble()
-        habit.targetType = Habit.AT_LEAST
-        habit.unit = unitInput.text.trim().toString()
+        if (habitType == Habit.NUMBER_HABIT) {
+            habit.targetValue = targetInput.text.toString().toDouble()
+            habit.targetType = Habit.AT_LEAST
+            habit.unit = unitInput.text.trim().toString()
+        }
         habit.type = habitType
 
         val command = if (habitId >= 0) {


### PR DESCRIPTION
Currently in the dev branch saving YES_NO habits is crashing because it can't parse the empty string value of `targetInput.text` as double.