### PR TITLE
Setting custom start of the day

### DIFF
--- a/android/uhabits-android/src/androidTest/java/org/isoron/uhabits/BaseAndroidTest.java
+++ b/android/uhabits-android/src/androidTest/java/org/isoron/uhabits/BaseAndroidTest.java
@@ -88,6 +88,7 @@ public class BaseAndroidTest extends TestCase
         testContext = InstrumentationRegistry.getInstrumentation().getContext();
 
         DateUtils.setFixedLocalTime(FIXED_LOCAL_TIME);
+        DateUtils.setStartDayOffset(0, 0);
         setResolution(2.0f);
         setTheme(R.style.AppBaseTheme);
         setLocale("en", "US");

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/HabitsApplication.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/HabitsApplication.kt
@@ -25,6 +25,7 @@ import org.isoron.androidbase.*
 import org.isoron.uhabits.core.database.*
 import org.isoron.uhabits.core.reminders.*
 import org.isoron.uhabits.core.ui.*
+import org.isoron.uhabits.core.utils.*
 import org.isoron.uhabits.utils.*
 import org.isoron.uhabits.widgets.*
 import java.io.*
@@ -59,6 +60,7 @@ class HabitsApplication : Application() {
             db.renameTo(File(db.absolutePath + ".invalid"))
             DatabaseUtils.initializeDatabase(context)
         }
+        DateUtils.setStartDayOffset(3, 0)
 
         widgetUpdater = component.widgetUpdater
         widgetUpdater.startListening()

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/BarChart.java
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/BarChart.java
@@ -391,7 +391,7 @@ public class BarChart extends ScrollableChart
     private float getMaxDayWidth()
     {
         float maxDayWidth = 0;
-        GregorianCalendar day = DateUtils.getStartOfTodayCalendar();
+        GregorianCalendar day = DateUtils.getStartOfTodayCalendarWithOffset();
 
         for (int i = 0; i < 28; i++)
         {
@@ -406,7 +406,7 @@ public class BarChart extends ScrollableChart
     private float getMaxMonthWidth()
     {
         float maxMonthWidth = 0;
-        GregorianCalendar day = DateUtils.getStartOfTodayCalendar();
+        GregorianCalendar day = DateUtils.getStartOfTodayCalendarWithOffset();
 
         for (int i = 0; i < 12; i++)
         {

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/FrequencyChart.java
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/FrequencyChart.java
@@ -153,7 +153,7 @@ public class FrequencyChart extends ScrollableChart
         pGraph.setColor(primaryColor);
         prevRect.setEmpty();
 
-        GregorianCalendar currentDate = DateUtils.getStartOfTodayCalendar();
+        GregorianCalendar currentDate = DateUtils.getStartOfTodayCalendarWithOffset();
         currentDate.set(Calendar.DAY_OF_MONTH, 1);
         currentDate.add(Calendar.MONTH, -nColumns + 2 - getDataOffset());
 
@@ -274,7 +274,7 @@ public class FrequencyChart extends ScrollableChart
     private float getMaxMonthWidth()
     {
         float maxMonthWidth = 0;
-        GregorianCalendar day = DateUtils.getStartOfTodayCalendar();
+        GregorianCalendar day = DateUtils.getStartOfTodayCalendarWithOffset();
 
         for (int i = 0; i < 12; i++)
         {

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/HistoryChart.java
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/HistoryChart.java
@@ -148,7 +148,7 @@ public class HistoryChart extends ScrollableChart
         final Timestamp timestamp = positionToTimestamp(x, y);
         if (timestamp == null) return false;
 
-        Timestamp today = DateUtils.getToday();
+        Timestamp today = DateUtils.getTodayWithOffset();
         int newValue = YES_MANUAL;
         int offset = timestamp.daysUntil(today);
         if (offset < checkmarks.length)
@@ -521,20 +521,20 @@ public class HistoryChart extends ScrollableChart
         Calendar date = (Calendar) baseDate.clone();
         date.add(Calendar.DAY_OF_YEAR, offset);
 
-        if (DateUtils.getStartOfDay(date.getTimeInMillis()) >
-            DateUtils.getStartOfToday()) return null;
+        if (DateUtils.getStartOfDayWithOffset(date.getTimeInMillis()) >
+            DateUtils.getStartOfTodayWithOffset()) return null;
 
         return new Timestamp(date.getTimeInMillis());
     }
 
     private void updateDate()
     {
-        baseDate = DateUtils.getStartOfTodayCalendar();
+        baseDate = DateUtils.getStartOfTodayCalendarWithOffset();
         baseDate.add(Calendar.DAY_OF_YEAR, -(getDataOffset() - 1) * 7);
 
         nDays = (nColumns - 1) * 7;
         int realWeekday =
-            DateUtils.getStartOfTodayCalendar().get(Calendar.DAY_OF_WEEK);
+            DateUtils.getStartOfTodayCalendarWithOffset().get(Calendar.DAY_OF_WEEK);
         todayPositionInColumn =
             (7 + realWeekday - firstWeekday) % 7;
 

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/ScoreChart.java
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/ScoreChart.java
@@ -357,7 +357,7 @@ public class ScoreChart extends ScrollableChart
     private float getMaxDayWidth()
     {
         float maxDayWidth = 0;
-        GregorianCalendar day = DateUtils.getStartOfTodayCalendar();
+        GregorianCalendar day = DateUtils.getStartOfTodayCalendarWithOffset();
 
         for (int i = 0; i < 28; i++)
         {
@@ -372,7 +372,7 @@ public class ScoreChart extends ScrollableChart
     private float getMaxMonthWidth()
     {
         float maxMonthWidth = 0;
-        GregorianCalendar day = DateUtils.getStartOfTodayCalendar();
+        GregorianCalendar day = DateUtils.getStartOfTodayCalendarWithOffset();
 
         for (int i = 0; i < 12; i++)
         {

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/CheckmarkPanelView.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/CheckmarkPanelView.kt
@@ -56,7 +56,7 @@ class CheckmarkPanelView(
 
     @Synchronized
     override fun setupButtons() {
-        val today = DateUtils.getToday()
+        val today = DateUtils.getTodayWithOffset()
 
         buttons.forEachIndexed { index, button ->
             val timestamp = today.minus(index + dataOffset)

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/HabitCardView.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/HabitCardView.kt
@@ -172,7 +172,7 @@ class HabitCardView(
     }
 
     fun triggerRipple(timestamp: Timestamp) {
-        val today = DateUtils.getToday()
+        val today = DateUtils.getTodayWithOffset()
         val offset = timestamp.daysUntil(today) - dataOffset
         val button = checkmarkPanel.buttons[offset]
         val y = button.height / 2.0f

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/HeaderView.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/HeaderView.kt
@@ -106,7 +106,7 @@ class HeaderView(
         }
 
         fun draw(canvas: Canvas) {
-            val day = getStartOfTodayCalendar()
+            val day = getStartOfTodayCalendarWithOffset()
             val width = dim(R.dimen.checkmarkWidth)
             val height = dim(R.dimen.checkmarkHeight)
             val isReversed = prefs.isCheckmarkSequenceReversed

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/NumberPanelView.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/NumberPanelView.kt
@@ -67,7 +67,7 @@ class NumberPanelView(
 
     @Synchronized
     override fun setupButtons() {
-        val today = DateUtils.getToday()
+        val today = DateUtils.getTodayWithOffset()
 
         buttons.forEachIndexed { index, button ->
             val timestamp = today.minus(index + dataOffset)

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/views/OverviewCard.java
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/views/OverviewCard.java
@@ -153,7 +153,7 @@ public class OverviewCard extends HabitCard
 
             ScoreList scores = habit.getScores();
 
-            Timestamp today = DateUtils.getToday();
+            Timestamp today = DateUtils.getTodayWithOffset();
             Timestamp lastMonth = today.minus(30);
             Timestamp lastYear = today.minus(365);
 

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/views/TargetCard.java
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/views/TargetCard.java
@@ -134,7 +134,7 @@ public class TargetCard extends HabitCard
         public void onPostExecute()
         {
             if (isCanceled()) return;
-            Calendar cal = DateUtils.getStartOfTodayCalendar();
+            Calendar cal = DateUtils.getStartOfTodayCalendarWithOffset();
             int daysInMonth = cal.getActualMaximum(Calendar.DAY_OF_MONTH);
             int daysInQuarter = 91;
             int daysInYear = cal.getActualMaximum(Calendar.DAY_OF_YEAR);

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/automation/FireSettingReceiver.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/automation/FireSettingReceiver.kt
@@ -45,7 +45,7 @@ class FireSettingReceiver : BroadcastReceiver() {
                 .build()
         allHabits = app.component.habitList
         val args = SettingUtils.parseIntent(intent, allHabits) ?: return
-        val timestamp = DateUtils.getToday()
+        val timestamp = DateUtils.getTodayWithOffset()
         val controller = component.widgetController
 
         when (args.action) {

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/intents/IntentParser.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/intents/IntentParser.kt
@@ -38,7 +38,7 @@ class IntentParser
 
     fun copyIntentData(source: Intent, destination: Intent) {
         destination.data = source.data;
-        destination.putExtra("timestamp", source.getLongExtra("timestamp", DateUtils.getToday().unixTime))
+        destination.putExtra("timestamp", source.getLongExtra("timestamp", DateUtils.getTodayWithOffset().unixTime))
     }
 
     private fun parseHabit(uri: Uri): Habit {
@@ -48,7 +48,7 @@ class IntentParser
     }
 
     private fun parseTimestamp(intent: Intent): Timestamp {
-        val today = DateUtils.getToday().unixTime
+        val today = DateUtils.getTodayWithOffset().unixTime
         var timestamp = intent.getLongExtra("timestamp", today)
         timestamp = DateUtils.getStartOfDay(timestamp)
 

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/receivers/ReminderReceiver.java
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/receivers/ReminderReceiver.java
@@ -62,7 +62,7 @@ public class ReminderReceiver extends BroadcastReceiver
         Log.i(TAG, String.format("Received intent: %s", intent.toString()));
 
         Habit habit = null;
-        long today = DateUtils.getStartOfToday();
+        long today = DateUtils.getStartOfTodayWithOffset();
 
         if (intent.getData() != null)
             habit = habits.getById(parseId(intent.getData()));

--- a/android/uhabits-android/src/main/java/org/isoron/uhabits/widgets/WidgetUpdater.kt
+++ b/android/uhabits-android/src/main/java/org/isoron/uhabits/widgets/WidgetUpdater.kt
@@ -64,7 +64,7 @@ class WidgetUpdater
     }
 
     fun scheduleStartDayWidgetUpdate() {
-        val timestamp = DateUtils.getStartOfTomorrow()
+        val timestamp = DateUtils.getStartOfTomorrowWithOffset()
         intentScheduler.scheduleWidgetUpdate(timestamp);
     }
 

--- a/android/uhabits-android/src/test/java/org/isoron/uhabits/BaseAndroidJVMTest.java
+++ b/android/uhabits-android/src/test/java/org/isoron/uhabits/BaseAndroidJVMTest.java
@@ -47,7 +47,7 @@ public class BaseAndroidJVMTest
     {
         long fixed_local_time = 1422172800000L;
         DateUtils.setFixedLocalTime(fixed_local_time);
-
+        DateUtils.setStartDayOffset(0, 0);
         modelFactory = new MemoryModelFactory();
         habitList = spy(modelFactory.buildHabitList());
         fixtures = new HabitFixtures(modelFactory, habitList);
@@ -59,6 +59,7 @@ public class BaseAndroidJVMTest
     public void tearDown()
     {
         DateUtils.setFixedLocalTime(null);
+        DateUtils.setStartDayOffset(0, 0);
     }
 
     public long timestamp(int year, int month, int day)

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/models/CheckmarkList.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/models/CheckmarkList.java
@@ -55,7 +55,7 @@ public abstract class CheckmarkList
     {
         if (reps.length == 0) throw new IllegalArgumentException();
 
-        Timestamp today = DateUtils.getToday();
+        Timestamp today = DateUtils.getTodayWithOffset();
         Timestamp begin = reps[0].getTimestamp();
         if (intervals.size() > 0) begin = Timestamp.oldest(begin, intervals.get(0).begin);
 
@@ -181,7 +181,7 @@ public abstract class CheckmarkList
         if (oldestRep == null) return new int[0];
 
         Timestamp fromTimestamp = oldestRep.getTimestamp();
-        Timestamp toTimestamp = DateUtils.getToday();
+        Timestamp toTimestamp = DateUtils.getTodayWithOffset();
 
         return getValues(fromTimestamp, toTimestamp);
     }
@@ -211,7 +211,7 @@ public abstract class CheckmarkList
     public synchronized final Checkmark getToday()
     {
         compute();
-        Timestamp today = DateUtils.getToday();
+        Timestamp today = DateUtils.getTodayWithOffset();
         return getByInterval(today, today).get(0);
     }
 
@@ -325,7 +325,7 @@ public abstract class CheckmarkList
      */
     protected final synchronized void compute()
     {
-        final Timestamp today = DateUtils.getToday();
+        final Timestamp today = DateUtils.getTodayWithOffset();
 
         Checkmark newest = getNewestComputed();
         if (newest != null && newest.getTimestamp().equals(today)) return;
@@ -334,6 +334,8 @@ public abstract class CheckmarkList
         Repetition oldestRep = habit.getRepetitions().getOldest();
         if (oldestRep == null) return;
         final Timestamp from = oldestRep.getTimestamp();
+
+        if (from.isNewerThan(today)) return;
 
         Repetition reps[] = habit
             .getRepetitions()
@@ -364,7 +366,7 @@ public abstract class CheckmarkList
     {
         if (reps.length == 0) return;
 
-        Timestamp today = DateUtils.getToday();
+        Timestamp today = DateUtils.getTodayWithOffset();
         Timestamp begin = reps[0].getTimestamp();
 
         int nDays = begin.daysUntil(today) + 1;
@@ -392,7 +394,7 @@ public abstract class CheckmarkList
     public List<Checkmark> getAll() {
         Repetition oldest = habit.getRepetitions().getOldest();
         if(oldest == null) return new ArrayList<>();
-        return getByInterval(oldest.getTimestamp(), DateUtils.getToday());
+        return getByInterval(oldest.getTimestamp(), DateUtils.getTodayWithOffset());
     }
 
     static final class Interval

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/models/RepetitionList.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/models/RepetitionList.java
@@ -135,7 +135,7 @@ public abstract class RepetitionList
     public HashMap<Timestamp, Integer[]> getWeekdayFrequency()
     {
         List<Repetition> reps =
-                getByInterval(Timestamp.ZERO, DateUtils.getToday());
+                getByInterval(Timestamp.ZERO, DateUtils.getTodayWithOffset());
         HashMap<Timestamp, Integer[]> map = new HashMap<>();
 
         for (Repetition r : reps)

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/models/ScoreList.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/models/ScoreList.java
@@ -69,7 +69,7 @@ public abstract class ScoreList implements Iterable<Score>
      */
     public double getTodayValue()
     {
-        return getValue(DateUtils.getToday());
+        return getValue(DateUtils.getTodayWithOffset());
     }
 
     /**
@@ -222,7 +222,7 @@ public abstract class ScoreList implements Iterable<Score>
         Repetition oldestRep = habit.getRepetitions().getOldest();
         if (oldestRep == null) return;
 
-        Timestamp today = DateUtils.getToday();
+        Timestamp today = DateUtils.getTodayWithOffset();
         compute(oldestRep.getTimestamp(), today);
     }
 

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/models/StreakList.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/models/StreakList.java
@@ -67,7 +67,7 @@ public abstract class StreakList
 
     public synchronized void rebuild()
     {
-        Timestamp today = DateUtils.getToday();
+        Timestamp today = DateUtils.getTodayWithOffset();
         Timestamp beginning = findBeginning();
         if (beginning == null || beginning.isNewerThan(today)) return;
 

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/reminders/ReminderScheduler.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/reminders/ReminderScheduler.java
@@ -121,7 +121,7 @@ public class ReminderScheduler implements CommandRunner.Listener
             return;
         }
 
-        long timestamp = getStartOfDay(removeTimezone(reminderTime));
+        long timestamp = getStartOfDayWithOffset(removeTimezone(reminderTime));
         sys.log("ReminderScheduler",
                 String.format(
                         Locale.US,

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/ui/screens/habits/list/HabitCardListCache.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/ui/screens/habits/list/HabitCardListCache.java
@@ -332,7 +332,7 @@ public class HabitCardListCache implements CommandRunner.Listener
             newData.copyScoresFrom(data);
             newData.copyCheckmarksFrom(data);
 
-            Timestamp dateTo = DateUtils.getToday();
+            Timestamp dateTo = DateUtils.getTodayWithOffset();
             Timestamp dateFrom = dateTo.minus(checkmarkCount - 1);
 
             if (runner != null) runner.publishProgress(this, -1);

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/utils/DateUtils.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/utils/DateUtils.java
@@ -202,19 +202,19 @@ public abstract class DateUtils
         return getStartOfDay(getLocalTime());
     }
 
-    public static long getStartOfTomorrow()
+    public static long getStartOfTomorrowWithOffset()
     {
         return getUpcomingTimeInMillis(startDayHourOffset, startDayMinuteOffset);
     }
-    
+
     public static long getStartOfTodayWithOffset()
     {
         return getStartOfDayWithOffset(getLocalTime());
     }
 
-    public static long millisecondsUntilTomorrow()
+    public static long millisecondsUntilTomorrowWithOffset()
     {
-        return getStartOfTomorrow() - getLocalTime();
+        return getStartOfTomorrowWithOffset() - getLocalTime();
     }
 
     public static GregorianCalendar getStartOfTodayCalendar()

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/utils/DateUtils.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/utils/DateUtils.java
@@ -37,10 +37,25 @@ public abstract class DateUtils
 
     private static Locale fixedLocale = null;
 
+    private static int startDayHourOffset = 0;
+
+    private static int startDayMinuteOffset = 0;
+
+    /**
+     * Number of milliseconds in one minute.
+     */
+
+    public static final long MINUTE_LENGTH = 60 * 1000;
+
+    /**
+     * Number of milliseconds in one hour.
+     */
+    public static final long HOUR_LENGTH = 60 * MINUTE_LENGTH;
+
     /**
      * Number of milliseconds in one day.
      */
-    public static final long DAY_LENGTH = 24 * 60 * 60 * 1000;
+    public static final long DAY_LENGTH = 24 * HOUR_LENGTH;
 
     public static long applyTimezone(long localTimestamp)
     {
@@ -165,9 +180,21 @@ public abstract class DateUtils
         return new Timestamp(getStartOfToday());
     }
 
+    @NonNull
+    public static Timestamp getTodayWithOffset()
+    {
+        return new Timestamp(getStartOfTodayWithOffset());
+    }
+
     public static long getStartOfDay(long timestamp)
     {
         return (timestamp / DAY_LENGTH) * DAY_LENGTH;
+    }
+
+    public static long getStartOfDayWithOffset(long timestamp)
+    {
+        long offset = startDayHourOffset * HOUR_LENGTH + startDayMinuteOffset * MINUTE_LENGTH;
+        return getStartOfDay(timestamp - offset);
     }
 
     public static long getStartOfToday()
@@ -177,7 +204,12 @@ public abstract class DateUtils
 
     public static long getStartOfTomorrow()
     {
-        return getUpcomingTimeInMillis(0, 0);
+        return getUpcomingTimeInMillis(startDayHourOffset, startDayMinuteOffset);
+    }
+    
+    public static long getStartOfTodayWithOffset()
+    {
+        return getStartOfDayWithOffset(getLocalTime());
     }
 
     public static long millisecondsUntilTomorrow()
@@ -188,6 +220,11 @@ public abstract class DateUtils
     public static GregorianCalendar getStartOfTodayCalendar()
     {
         return getCalendar(getStartOfToday());
+    }
+
+    public static GregorianCalendar getStartOfTodayCalendarWithOffset()
+    {
+        return getCalendar(getStartOfTodayWithOffset());
     }
 
     private static TimeZone getTimezone()
@@ -215,6 +252,12 @@ public abstract class DateUtils
     public static void setFixedLocale(Locale locale)
     {
         fixedLocale = locale;
+    }
+
+    public static void setStartDayOffset(int hourOffset, int minuteOffset)
+    {
+        startDayHourOffset = hourOffset;
+        startDayMinuteOffset = minuteOffset;
     }
 
     private static Locale getLocale()

--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/utils/MidnightTimer.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/utils/MidnightTimer.java
@@ -56,7 +56,7 @@ public class MidnightTimer
     {
         executor = Executors.newSingleThreadScheduledExecutor();
         executor.scheduleAtFixedRate(() -> notifyListeners(),
-            DateUtils.millisecondsUntilTomorrow() + 1000,
+            DateUtils.millisecondsUntilTomorrowWithOffset() + 1000,
             DateUtils.DAY_LENGTH, TimeUnit.MILLISECONDS);
     }
 

--- a/android/uhabits-core/src/test/java/org/isoron/uhabits/core/BaseUnitTest.java
+++ b/android/uhabits-core/src/test/java/org/isoron/uhabits/core/BaseUnitTest.java
@@ -78,6 +78,7 @@ public class BaseUnitTest
     public void setUp() throws Exception
     {
         DateUtils.setFixedLocalTime(FIXED_LOCAL_TIME);
+        DateUtils.setStartDayOffset(0, 0);
 
         modelFactory = new MemoryModelFactory();
         habitList = spy(modelFactory.buildHabitList());
@@ -91,6 +92,7 @@ public class BaseUnitTest
     {
         validateMockitoUsage();
         DateUtils.setFixedLocalTime(null);
+        DateUtils.setStartDayOffset(0, 0);
     }
 
     public long unixTime(int year, int month, int day)

--- a/android/uhabits-core/src/test/java/org/isoron/uhabits/core/utils/DateUtilsTest.java
+++ b/android/uhabits-core/src/test/java/org/isoron/uhabits/core/utils/DateUtilsTest.java
@@ -180,6 +180,29 @@ public class DateUtilsTest extends BaseUnitTest
     }
 
     @Test
+    public void testGetTodayWithOffset() throws Exception
+    {
+        assertThat(DateUtils.getTodayWithOffset(), equalTo(new Timestamp(FIXED_LOCAL_TIME)));
+        DateUtils.setStartDayOffset(9, 0);
+        assertThat(
+                DateUtils.getTodayWithOffset(),
+                equalTo(new Timestamp(FIXED_LOCAL_TIME - DAY_LENGTH)));
+    }
+
+    @Test
+    public void testGetStartOfDayWithOffset() throws Exception
+    {
+        long timestamp = unixTime(2020, SEPTEMBER, 3);
+        assertThat(
+                DateUtils.getStartOfDayWithOffset(timestamp + HOUR_LENGTH),
+                equalTo(timestamp));
+        DateUtils.setStartDayOffset(3, 30);
+        assertThat(
+                DateUtils.getStartOfDayWithOffset(timestamp + 3 * HOUR_LENGTH + 29 * MINUTE_LENGTH),
+                equalTo(timestamp - DAY_LENGTH));
+    }
+
+    @Test
     public void test_applyTimezone()
     {
         DateUtils.setFixedTimeZone(TimeZone.getTimeZone("Australia/Sydney"));

--- a/android/uhabits-core/src/test/java/org/isoron/uhabits/core/utils/DateUtilsTest.java
+++ b/android/uhabits-core/src/test/java/org/isoron/uhabits/core/utils/DateUtilsTest.java
@@ -166,17 +166,17 @@ public class DateUtilsTest extends BaseUnitTest
         DateUtils.setFixedTimeZone(TimeZone.getTimeZone("GMT"));
 
         DateUtils.setFixedLocalTime(unixTime(2017, JANUARY, 1, 23, 59));
-        assertThat(DateUtils.millisecondsUntilTomorrow(), equalTo(MINUTE_LENGTH));
+        assertThat(DateUtils.millisecondsUntilTomorrowWithOffset(), equalTo(MINUTE_LENGTH));
 
         DateUtils.setFixedLocalTime(unixTime(2017, JANUARY, 1, 20, 0));
-        assertThat(DateUtils.millisecondsUntilTomorrow(), equalTo(4 * HOUR_LENGTH));
+        assertThat(DateUtils.millisecondsUntilTomorrowWithOffset(), equalTo(4 * HOUR_LENGTH));
 
         DateUtils.setStartDayOffset(3, 30);
         DateUtils.setFixedLocalTime(unixTime(2017, JANUARY, 1, 23, 59));
-        assertThat(DateUtils.millisecondsUntilTomorrow(), equalTo(3 * HOUR_LENGTH + 31 * MINUTE_LENGTH));
+        assertThat(DateUtils.millisecondsUntilTomorrowWithOffset(), equalTo(3 * HOUR_LENGTH + 31 * MINUTE_LENGTH));
 
         DateUtils.setFixedLocalTime(unixTime(2017, JANUARY, 2, 1, 0));
-        assertThat(DateUtils.millisecondsUntilTomorrow(), equalTo(2 * HOUR_LENGTH + 30 * MINUTE_LENGTH));
+        assertThat(DateUtils.millisecondsUntilTomorrowWithOffset(), equalTo(2 * HOUR_LENGTH + 30 * MINUTE_LENGTH));
     }
 
     @Test

--- a/android/uhabits-core/src/test/java/org/isoron/uhabits/core/utils/DateUtilsTest.java
+++ b/android/uhabits-core/src/test/java/org/isoron/uhabits/core/utils/DateUtilsTest.java
@@ -29,8 +29,7 @@ import static java.util.Calendar.*;
 import static junit.framework.Assert.assertEquals;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
-import static org.isoron.uhabits.core.utils.DateUtils.applyTimezone;
-import static org.isoron.uhabits.core.utils.DateUtils.removeTimezone;
+import static org.isoron.uhabits.core.utils.DateUtils.*;
 
 public class DateUtilsTest extends BaseUnitTest
 {
@@ -165,12 +164,19 @@ public class DateUtilsTest extends BaseUnitTest
     public void testMillisecondsUntilTomorrow() throws Exception
     {
         DateUtils.setFixedTimeZone(TimeZone.getTimeZone("GMT"));
+
         DateUtils.setFixedLocalTime(unixTime(2017, JANUARY, 1, 23, 59));
-        assertThat(DateUtils.millisecondsUntilTomorrow(), equalTo(60000L));
+        assertThat(DateUtils.millisecondsUntilTomorrow(), equalTo(MINUTE_LENGTH));
 
         DateUtils.setFixedLocalTime(unixTime(2017, JANUARY, 1, 20, 0));
-        assertThat(DateUtils.millisecondsUntilTomorrow(), equalTo(14400000L));
+        assertThat(DateUtils.millisecondsUntilTomorrow(), equalTo(4 * HOUR_LENGTH));
 
+        DateUtils.setStartDayOffset(3, 30);
+        DateUtils.setFixedLocalTime(unixTime(2017, JANUARY, 1, 23, 59));
+        assertThat(DateUtils.millisecondsUntilTomorrow(), equalTo(3 * HOUR_LENGTH + 31 * MINUTE_LENGTH));
+
+        DateUtils.setFixedLocalTime(unixTime(2017, JANUARY, 2, 1, 0));
+        assertThat(DateUtils.millisecondsUntilTomorrow(), equalTo(2 * HOUR_LENGTH + 30 * MINUTE_LENGTH));
     }
 
     @Test


### PR DESCRIPTION
Implements https://github.com/iSoron/uhabits/issues/607.
1) Instead of hard-coding 3 AM like the last time this was implemented, I decided to add it as a setting so everyone can set whatever time they desire to start the new day.
2) Tested it through the app, widgets and notifications and checks go to the appropriate day, UI doesn't move to the next day until you pass the custom mark and notifications arrive as usual so they aren't affected by the offset.
3) It was bugging me that widgets don't automatically refresh when the new day starts, so also implemented that in this PR (even if we don't merge this, we should add this to the main app).

As usual waiting for feedback from @iSoron before I start writing tests for the functionality and will be dog fooding this version in the mean time.