### PR TITLE
Make skips freeze score

### DIFF
--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/models/ScoreList.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/models/ScoreList.java
@@ -286,7 +286,7 @@ public abstract class ScoreList implements Iterable<Score>
                 double percentageCompleted = Math.min(1, rollingSum / 1000 / habit.getTargetValue());
                 previousValue = Score.compute(1.0, previousValue, percentageCompleted);
             }
-            else
+            else if (checkmarkValues[offset] != Checkmark.SKIP)
             {
                 double value = Math.min(1, checkmarkValues[offset]);
                 previousValue = Score.compute(freq, previousValue, value);

--- a/android/uhabits-core/src/test/java/org/isoron/uhabits/core/models/ScoreListTest.java
+++ b/android/uhabits-core/src/test/java/org/isoron/uhabits/core/models/ScoreListTest.java
@@ -126,6 +126,49 @@ public class ScoreListTest extends BaseUnitTest
     }
 
     @Test
+    public void test_getValueWithSkip()
+    {
+        toggleRepetitions(0, 20);
+        addSkip(5);
+        addSkip(10);
+        addSkip(11);
+
+        double expectedValues[] = {
+                0.596033,
+                0.573910,
+                0.550574,
+                0.525961,
+                0.500000,
+                0.472617,
+                0.472617,
+                0.443734,
+                0.413270,
+                0.381137,
+                0.347244,
+                0.347244,
+                0.347244,
+                0.311495,
+                0.273788,
+                0.234017,
+                0.192067,
+                0.147820,
+                0.101149,
+                0.051922,
+                0.000000,
+                0.000000,
+                0.000000
+        };
+
+        ScoreList scores = habit.getScores();
+        Timestamp current = DateUtils.getToday();
+        for (double expectedValue : expectedValues)
+        {
+            assertThat(scores.getValue(current), closeTo(expectedValue, E));
+            current = current.minus(1);
+        }
+    }
+
+    @Test
     public void test_getValues()
     {
         toggleRepetitions(0, 20);
@@ -196,5 +239,12 @@ public class ScoreListTest extends BaseUnitTest
 
         for (int i = from; i < to; i++)
             reps.toggle(today.minus(i));
+    }
+
+    private void addSkip(final int day)
+    {
+        RepetitionList reps = habit.getRepetitions();
+        Timestamp today = DateUtils.getToday();
+        reps.toggle(today.minus(day), Checkmark.SKIP);
     }
 }


### PR DESCRIPTION
The way skip days are currently implemented in the app have a couple of problems. The biggest one of them is that they are no different than a check for the current day, and only distinct visually, making them a visual gimmick.
The desire for skip days comes from situations where a habit can neither be completed or failed, it's just not valid for a given day. In those days the person can add a check not to break score/streak, but then he is getting rewarded for doing nothing and it feels like cheating. Another thing you can do it is let them be unchecked, but then you are being penalized for things outside of your control (sick days, inability because of location, etc.). The way the app currently implements them is the same as adding a check (which feels like cheating and rewards you for doing nothing), but only visually saves that something happened that day.
A couple of concrete examples why the current behavior doesn't work:
### Streaks
1) For a daily habit that I skipped Mon-Wed, did it on Thu, and skipped Friday-Sunday, the app will tell me I have a streak of 7 days. In reality I just did it a single day so my streak should be 1. (**Beginning and ending a streak with skipped days doesn't make sense**)
2) If in January I did a daily habit 7 days in a row, that is a streak of 7. If then in February I do the habit once on monday, once on sunday and skip everything in between, the app will also reward me a streak of 7, even though the one in february I barely did the habit. They shouldn't be equal. (**Skipped days shouldn't be counted as successful days in streak**).
3) Something both implementations get right is that if you skip a couple of days between successful repetitions, this shouldn't end your streak. (**Failing only occurs on a day when that was possible, not skipped and not implicitly checked day with missing repetition**)
### Score
1) Today in the app skipping 67 days in a row gives you 100% score as if you mastered the habit even though you didn't do a single repetition. (**Skipping days shouldn't be rewarding, it should be neutral**)
2) If I have been doing a daily habit successfully for a month (e.g. workout every day) and then have an injury that makes it impossible to continue doing the habit for another month. You shouldn't get rewarded for this month of injury when you weren't working out, but you shouldn't also get penalized for it by losing all your progress. In terms of that habit your score should be frozen until you can do the habit again and you can keep tracking it. The same applies for a work habit that is invalid on weekends, you shouldn't get rewarded or penalized for skipping it during the weekend or during a vacation. (**Skipping days shouldn't penalize you because the habit was not possible to complete**).

This PR implements fixes for those problems:
1) Skip days don't break streaks but are also excluded from the number of successful days you were in a streak to give more days when doing the habit, instead of just skipping it.
2) Skip days don't change the score for the current day and just freeze the score from the previous one.