### PR TITLE
Fix habit selection menu item background color

### DIFF
--- a/android/uhabits-android/src/main/res/values/styles.xml
+++ b/android/uhabits-android/src/main/res/values/styles.xml
@@ -23,6 +23,7 @@
         <item name="android:dialogTheme">@style/Theme.AppCompat.Light.Dialog</item>
         <item name="android:alertDialogTheme">@style/Theme.AppCompat.Light.Dialog</item>
         <item name="android:navigationBarColor">?attr/colorPrimary</item>
+        <item name="android:itemBackground">?attr/highContrastReverseTextColor</item>
 
         <item name="windowActionModeOverlay">true</item>
         <item name="actionModeBackground">@color/blue_grey_700</item>


### PR DESCRIPTION
When using a dark theme the menu for actions of selected habits has a white background on white text.
![image](https://user-images.githubusercontent.com/3768676/91845389-bc199f00-ec61-11ea-97fc-9e0c0fc77058.png)
After this PR:
![image](https://user-images.githubusercontent.com/3768676/91845396-c045bc80-ec61-11ea-8d1f-57ea877e2bf4.png)
