### PR TITLE
Don't show reminders from archived habits

### DIFF
--- a/android/uhabits-core/src/main/java/org/isoron/uhabits/core/ui/NotificationTray.java
+++ b/android/uhabits-core/src/main/java/org/isoron/uhabits/core/ui/NotificationTray.java
@@ -194,18 +194,27 @@ public class NotificationTray
                 return;
             }
 
-            if (!shouldShowReminderToday()) {
-                systemTray.log(String.format(
-                        Locale.US,
-                        "Habit %d not supposed to run today. Skipping.",
-                        habit.id));
-                return;
-            }
-
             if (!habit.hasReminder()) {
                 systemTray.log(String.format(
                         Locale.US,
                         "Habit %d does not have a reminder. Skipping.",
+                        habit.id));
+                return;
+            }
+
+            if (habit.isArchived())
+            {
+                systemTray.log(String.format(
+                        Locale.US,
+                        "Habit %d is archived. Skipping.",
+                        habit.id));
+                return;
+            }
+
+            if (!shouldShowReminderToday()) {
+                systemTray.log(String.format(
+                        Locale.US,
+                        "Habit %d not supposed to run today. Skipping.",
                         habit.id));
                 return;
             }


### PR DESCRIPTION
Currently when you archive a habit with a pending reminder, it still gets shown that day. Afterwards it correctly doesn't schedule it anymore.