### PR TITLE
Disable transparency for stacked widgets

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/BaseWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/BaseWidget.kt
@@ -33,12 +33,13 @@ import org.isoron.uhabits.core.preferences.Preferences
 import org.isoron.uhabits.core.preferences.WidgetPreferences
 import org.isoron.uhabits.intents.PendingIntentFactory
 
-abstract class BaseWidget(val context: Context, val id: Int) {
+abstract class BaseWidget(val context: Context, val id: Int, val stacked: Boolean) {
     private val widgetPrefs: WidgetPreferences
     protected val prefs: Preferences
     protected val pendingIntentFactory: PendingIntentFactory
     protected val commandRunner: CommandRunner
     private var dimensions: WidgetDimensions
+
     fun delete() {
         widgetPrefs.removeWidget(id)
     }
@@ -144,7 +145,12 @@ abstract class BaseWidget(val context: Context, val id: Int) {
     }
 
     protected val preferedBackgroundAlpha: Int
-        get() = prefs.widgetOpacity
+        get() {
+            return if (stacked)
+                255
+            else
+                prefs.widgetOpacity
+        }
 
     init {
         val app = context.applicationContext as HabitsApplication

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/CheckmarkWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/CheckmarkWidget.kt
@@ -34,7 +34,8 @@ open class CheckmarkWidget(
     context: Context,
     widgetId: Int,
     protected val habit: Habit,
-) : BaseWidget(context, widgetId) {
+    stacked: Boolean = false,
+) : BaseWidget(context, widgetId, stacked) {
 
     override val defaultHeight: Int = 125
     override val defaultWidth: Int = 125

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/EmptyWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/EmptyWidget.kt
@@ -27,7 +27,8 @@ import org.isoron.uhabits.widgets.views.EmptyWidgetView
 class EmptyWidget(
     context: Context,
     widgetId: Int,
-) : BaseWidget(context, widgetId) {
+    stacked: Boolean = false,
+) : BaseWidget(context, widgetId, stacked) {
     override val defaultHeight: Int = 200
     override val defaultWidth: Int = 200
 

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/FrequencyWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/FrequencyWidget.kt
@@ -32,7 +32,8 @@ class FrequencyWidget(
     widgetId: Int,
     private val habit: Habit,
     private val firstWeekday: Int,
-) : BaseWidget(context, widgetId) {
+    stacked: Boolean = false,
+) : BaseWidget(context, widgetId, stacked) {
     override val defaultHeight: Int = 200
     override val defaultWidth: Int = 200
 

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/HistoryWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/HistoryWidget.kt
@@ -36,7 +36,8 @@ class HistoryWidget(
     context: Context,
     id: Int,
     private val habit: Habit,
-) : BaseWidget(context, id) {
+    stacked: Boolean = false,
+) : BaseWidget(context, id, stacked) {
 
     override val defaultHeight: Int = 250
     override val defaultWidth: Int = 250

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/ScoreWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/ScoreWidget.kt
@@ -32,7 +32,8 @@ class ScoreWidget(
     context: Context,
     id: Int,
     private val habit: Habit,
-) : BaseWidget(context, id) {
+    stacked: Boolean = false,
+) : BaseWidget(context, id, stacked) {
     override val defaultHeight: Int = 300
     override val defaultWidth: Int = 300
 

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/StackWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/StackWidget.kt
@@ -34,7 +34,8 @@ class StackWidget(
     widgetId: Int,
     private val widgetType: StackWidgetType,
     private val habits: List<Habit>,
-) : BaseWidget(context, widgetId) {
+    stacked: Boolean = true,
+) : BaseWidget(context, widgetId, stacked) {
     override val defaultHeight: Int = 0
     override val defaultWidth: Int = 0
 
@@ -51,7 +52,8 @@ class StackWidget(
 
     override fun getRemoteViews(width: Int, height: Int): RemoteViews {
         val manager = AppWidgetManager.getInstance(context)
-        val remoteViews = RemoteViews(context.packageName, StackWidgetType.getStackWidgetLayoutId(widgetType))
+        val remoteViews =
+            RemoteViews(context.packageName, StackWidgetType.getStackWidgetLayoutId(widgetType))
         val serviceIntent = Intent(context, StackWidgetService::class.java)
         val habitIds = StringUtils.joinLongs(habits.map { it.id!! }.toLongArray())
 
@@ -59,8 +61,14 @@ class StackWidget(
         serviceIntent.putExtra(StackWidgetService.WIDGET_TYPE, widgetType.value)
         serviceIntent.putExtra(StackWidgetService.HABIT_IDS, habitIds)
         serviceIntent.data = Uri.parse(serviceIntent.toUri(Intent.URI_INTENT_SCHEME))
-        remoteViews.setRemoteAdapter(StackWidgetType.getStackWidgetAdapterViewId(widgetType), serviceIntent)
-        manager.notifyAppWidgetViewDataChanged(id, StackWidgetType.getStackWidgetAdapterViewId(widgetType))
+        remoteViews.setRemoteAdapter(
+            StackWidgetType.getStackWidgetAdapterViewId(widgetType),
+            serviceIntent
+        )
+        manager.notifyAppWidgetViewDataChanged(
+            id,
+            StackWidgetType.getStackWidgetAdapterViewId(widgetType)
+        )
         remoteViews.setEmptyView(
             StackWidgetType.getStackWidgetAdapterViewId(widgetType),
             StackWidgetType.getStackWidgetEmptyViewId(widgetType)

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/StackWidgetService.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/StackWidgetService.kt
@@ -94,16 +94,17 @@ internal class StackRemoteViewsFactory(private val context: Context, intent: Int
         prefs: Preferences
     ): BaseWidget {
         when (widgetType) {
-            StackWidgetType.CHECKMARK -> return CheckmarkWidget(context, widgetId, habit)
+            StackWidgetType.CHECKMARK -> return CheckmarkWidget(context, widgetId, habit, true)
             StackWidgetType.FREQUENCY -> return FrequencyWidget(
                 context,
                 widgetId,
                 habit,
-                prefs.firstWeekdayInt
+                prefs.firstWeekdayInt,
+                true
             )
-            StackWidgetType.SCORE -> return ScoreWidget(context, widgetId, habit)
-            StackWidgetType.HISTORY -> return HistoryWidget(context, widgetId, habit)
-            StackWidgetType.STREAKS -> return StreakWidget(context, widgetId, habit)
+            StackWidgetType.SCORE -> return ScoreWidget(context, widgetId, habit, true)
+            StackWidgetType.HISTORY -> return HistoryWidget(context, widgetId, habit, true)
+            StackWidgetType.STREAKS -> return StreakWidget(context, widgetId, habit, true)
         }
         throw IllegalStateException()
     }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/StreakWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/StreakWidget.kt
@@ -33,7 +33,8 @@ class StreakWidget(
     context: Context,
     id: Int,
     private val habit: Habit,
-) : BaseWidget(context, id) {
+    stacked: Boolean = false,
+) : BaseWidget(context, id, stacked) {
     override val defaultHeight: Int = 200
     override val defaultWidth: Int = 200
 

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/TargetWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/TargetWidget.kt
@@ -36,7 +36,8 @@ class TargetWidget(
     context: Context,
     id: Int,
     private val habit: Habit,
-) : BaseWidget(context, id) {
+    stacked: Boolean = false,
+) : BaseWidget(context, id, stacked) {
     override val defaultHeight: Int = 200
     override val defaultWidth: Int = 200
 


### PR DESCRIPTION
I've added a "stacked" argument and changed the getter accordingly. Honestly I'm not sure you'll find it clean, so let me know if you'd rather have a different solution.