### PR TITLE
Implement the midnight delay option (alternative)

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/HabitsApplication.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/HabitsApplication.kt
@@ -24,7 +24,7 @@ import android.content.Context
 import org.isoron.uhabits.core.database.UnsupportedDatabaseVersionException
 import org.isoron.uhabits.core.reminders.ReminderScheduler
 import org.isoron.uhabits.core.ui.NotificationTray
-import org.isoron.uhabits.core.utils.DateUtils
+import org.isoron.uhabits.core.utils.DateUtils.Companion.setStartDayOffset
 import org.isoron.uhabits.inject.AppContextModule
 import org.isoron.uhabits.inject.DaggerHabitsApplicationComponent
 import org.isoron.uhabits.inject.HabitsApplicationComponent
@@ -67,23 +67,28 @@ class HabitsApplication : Application() {
             .habitsModule(HabitsModule(db))
             .build()
 
-        DateUtils.setStartDayOffset(3, 0)
+        val prefs = component.preferences
+        prefs.lastAppVersion = BuildConfig.VERSION_CODE
+
+        if (prefs.isMidnightDelayEnabled) {
+            setStartDayOffset(3, 0)
+        } else {
+            setStartDayOffset(0, 0)
+        }
 
         val habitList = component.habitList
         for (h in habitList) h.recompute()
 
-        widgetUpdater = component.widgetUpdater
-        widgetUpdater.startListening()
-        widgetUpdater.scheduleStartDayWidgetUpdate()
+        widgetUpdater = component.widgetUpdater.apply {
+            startListening()
+            scheduleStartDayWidgetUpdate()
+        }
 
         reminderScheduler = component.reminderScheduler
         reminderScheduler.startListening()
 
         notificationTray = component.notificationTray
         notificationTray.startListening()
-
-        val prefs = component.preferences
-        prefs.lastAppVersion = BuildConfig.VERSION_CODE
 
         val taskRunner = component.taskRunner
         taskRunner.execute {

--- a/uhabits-android/src/main/java/org/isoron/uhabits/preferences/SharedPreferencesStorage.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/preferences/SharedPreferencesStorage.kt
@@ -86,6 +86,8 @@ class SharedPreferencesStorage
         when (key) {
             "pref_checkmark_reverse_order" ->
                 preferences.isCheckmarkSequenceReversed = getBoolean(key, false)
+            "pref_midnight_delay" ->
+                preferences.isMidnightDelayEnabled = getBoolean(key, false)
             "pref_sticky_notifications" ->
                 preferences.setNotificationsSticky(getBoolean(key, false))
             "pref_led_notifications" ->

--- a/uhabits-android/src/main/res/values/strings.xml
+++ b/uhabits-android/src/main/res/values/strings.xml
@@ -240,4 +240,6 @@
     <string name="pref_unknown_description">Differentiate days without data from actual lapses. To enter a lapse, toggle twice.</string>
     <string name="you_are_now_a_developer">You are now a developer</string>
     <string name="activity_not_found">No app was found to support this action</string>
+    <string name="pref_midnight_delay_title">Extend day a few hours past midnight</string>
+    <string name="pref_midnight_delay_description">Wait until 3:00 AM to show a new day. Useful if you typically go to sleep after midnight. N.B.: this setting will not take effect until you restart the app.</string>
 </resources>

--- a/uhabits-android/src/main/res/xml/preferences.xml
+++ b/uhabits-android/src/main/res/xml/preferences.xml
@@ -33,6 +33,13 @@
 
         <CheckBoxPreference
             android:defaultValue="false"
+            android:key="pref_midnight_delay"
+            android:summary="@string/pref_midnight_delay_description"
+            android:title="@string/pref_midnight_delay_title"
+            app:iconSpaceReserved="false" />
+
+        <CheckBoxPreference
+            android:defaultValue="false"
             android:key="pref_skip_enabled"
             android:summary="@string/pref_skip_description"
             android:title="@string/pref_skip_title"

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/preferences/Preferences.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/preferences/Preferences.kt
@@ -183,6 +183,13 @@ open class Preferences(private val storage: Storage) {
             for (l in listeners) l.onCheckmarkSequenceChanged()
         }
 
+    open var isMidnightDelayEnabled: Boolean
+        get() = storage.getBoolean("pref_midnight_delay", false)
+        set(enabled) {
+            storage.putBoolean("pref_midnight_delay", enabled)
+            for (l in listeners) l.onCheckmarkSequenceChanged()
+        }
+
     fun updateLastHint(number: Int, timestamp: Timestamp) {
         storage.putInt("last_hint_number", number)
         storage.putLong("last_hint_timestamp", timestamp.unixTime)

--- a/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/preferences/PreferencesTest.kt
+++ b/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/preferences/PreferencesTest.kt
@@ -167,4 +167,12 @@ class PreferencesTest : BaseUnitTest() {
         assertTrue(prefs.showArchived)
         assertFalse(prefs.showCompleted)
     }
+
+    @Test
+    @Throws(Exception::class)
+    fun testMidnightDelay() {
+        assertFalse(prefs.isMidnightDelayEnabled)
+        prefs.isMidnightDelayEnabled = true
+        assertTrue(prefs.isMidnightDelayEnabled)
+    }
 }


### PR DESCRIPTION
Closes #694.

Follow-up from https://github.com/iSoron/uhabits/pull/717: I think it actually makes sense to tell the user that the app will have to restart for the setting to take effect, and keep the implementation clean, given that users will probably not tick the setting on and off regularly anyway. That would be this PR.

Let me know if I should go back to the previous one and make sure the setting applies right away.