### PR TITLE
Restore notification sound customization setting

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/settings/SettingsFragment.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/settings/SettingsFragment.kt
@@ -123,9 +123,13 @@ class SettingsFragment : PreferenceFragmentCompat(), OnSharedPreferenceChangeLis
         updateWeekdayPreference()
         updateSyncPreferences()
 
-        // Temporarily disable this; we now always ask
-        findPreference("reminderSound").isVisible = false
         findPreference("pref_snooze_interval").isVisible = false
+
+        if (VERSION.SDK_INT < Build.VERSION_CODES.O)
+            findPreference("reminderCustomize").isVisible = false
+        else {
+            findPreference("reminderSound").isVisible = false
+        }
     }
 
     private fun updateSyncPreferences() {

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/settings/SettingsFragment.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/settings/SettingsFragment.kt
@@ -123,8 +123,6 @@ class SettingsFragment : PreferenceFragmentCompat(), OnSharedPreferenceChangeLis
         updateWeekdayPreference()
         updateSyncPreferences()
 
-        findPreference("pref_snooze_interval").isVisible = false
-
         if (VERSION.SDK_INT < Build.VERSION_CODES.O)
             findPreference("reminderCustomize").isVisible = false
         else {

--- a/uhabits-android/src/main/res/values-ar-rSA/strings.xml
+++ b/uhabits-android/src/main/res/values-ar-rSA/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">مخصص...</string>
     <string name="pref_toggle_title">تبديل وضعية العادة بضغطة قصيرة</string>
     <string name="pref_toggle_description">وضع علامات الاختيار الموجودة بنقرة واحدة بدلاً من الصحافة وعقد. أكثر ملاءمة، ولكن قد يتسبب في تبديل عرضي.</string>
-    <string name="pref_snooze_interval_title">فترتي الغفوى على التذكير</string>
     <string name="pref_rate_this_app">تقييم هذا التطبيق على جوجل بلاي</string>
     <string name="pref_send_feedback">أرسل الملاحظات إلى المطور</string>
     <string name="pref_view_source_code">إفحص التعليمات البرمجية على GitHub</string>
     <string name="links">روابط</string>
     <string name="name">اسم</string>
     <string name="settings">إعدادات</string>
-    <string name="snooze_interval">فترتي الغفوه</string>
     <string name="select_snooze_delay">حدد تأخير الغفوة</string>
     <string name="hint_title">هل كنت تعلم؟</string>
     <string name="hint_drag">لإعادة ترتيب القوائم، أضغط اسم من هذه العادة، ثم اسحبه إلى المكان الصحيح.</string>

--- a/uhabits-android/src/main/res/values-bg-rBG/strings.xml
+++ b/uhabits-android/src/main/res/values-bg-rBG/strings.xml
@@ -66,14 +66,12 @@
     <string name="interval_24_hour">24 часа</string>
     <string name="pref_toggle_title">Маркиране с кратко натискане</string>
     <string name="pref_toggle_description">Поставяне на отметки с кратко натискане вместо с натискане и задържане. По-удобно, но може да доведе до неволно маркиране.</string>
-    <string name="pref_snooze_interval_title">Интервал на напомняне след отлагане</string>
     <string name="pref_rate_this_app">Оценяване на това приложение в Google Play</string>
     <string name="pref_send_feedback">Изпращане на отзиви към разработчика</string>
     <string name="pref_view_source_code">Преглед на програмния код в GitHub</string>
     <string name="links">Препратки</string>
     <string name="name">Име</string>
     <string name="settings">Настройки</string>
-    <string name="snooze_interval">Интервал на отлагане</string>
     <string name="hint_title">Знаете ли че?</string>
     <string name="hint_drag">За да пренаредите записите, натиснете и задръжте върху името на навика и го придърпайте до правилното място.</string>
     <string name="hint_landscape">Може да виждате повече дни като обърнете телефона си в хоризонтално положение.</string>

--- a/uhabits-android/src/main/res/values-ca-rES/strings.xml
+++ b/uhabits-android/src/main/res/values-ca-rES/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">Personalitza...</string>
     <string name="pref_toggle_title">Activar/desactivar repeticions prement curt</string>
     <string name="pref_toggle_description">Posar les marques de verificació amb un sol toc enlloc de prémer i mantenir. Més adequat, però pot causar activacions accidentals.</string>
-    <string name="pref_snooze_interval_title">Interval d\'endarreriment en recordatoris</string>
     <string name="pref_rate_this_app">Valora aquesta app a Google Play</string>
     <string name="pref_send_feedback">Enviar resposta al desenvolupador</string>
     <string name="pref_view_source_code">Veure codi font a Github</string>
     <string name="links">Enllaços</string>
     <string name="name">Nom</string>
     <string name="settings">Ajustaments</string>
-    <string name="snooze_interval">Interval d\'endarreriment</string>
     <string name="select_snooze_delay">Selecciona el retard de l\'endarreriment</string>
     <string name="hint_title">Ho sabies?</string>
     <string name="hint_drag">Per a ordenar les entrades, prem i mantè sobre el nom de l\'hàbit, després arrossega\'l al lloc correcte.</string>

--- a/uhabits-android/src/main/res/values-cs-rCZ/strings.xml
+++ b/uhabits-android/src/main/res/values-cs-rCZ/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">Vlastní...</string>
     <string name="pref_toggle_title">Označte opakování krátkým stisknutím</string>
     <string name="pref_toggle_description">Praktičtější, ale může způsobit nechtěné označení.</string>
-    <string name="pref_snooze_interval_title">Doba odložení upomínky</string>
     <string name="pref_rate_this_app">Ohodnoťte nás v Google Play</string>
     <string name="pref_send_feedback">Zpětná vazba vývojáři</string>
     <string name="pref_view_source_code">Zobrazit zdroj. kód na GitHub</string>
     <string name="links">Odkazy</string>
     <string name="name">Jméno</string>
     <string name="settings">Nastavení</string>
-    <string name="snooze_interval">Interval odkladu</string>
     <string name="select_snooze_delay">Nastavit délku odložení</string>
     <string name="hint_title">Věděli jste?</string>
     <string name="hint_drag">Přeřazení záznamů proveď stisknutím a podržením názvu zvyku a poté přesunutím na správné místo.</string>

--- a/uhabits-android/src/main/res/values-da-rDK/strings.xml
+++ b/uhabits-android/src/main/res/values-da-rDK/strings.xml
@@ -66,14 +66,12 @@
     <string name="interval_24_hour">24 timer</string>
     <string name="pref_toggle_title">Tjek vaner med kort tryk</string>
     <string name="pref_toggle_description">Sæt tjekmærker med et enkelt tryk i stedet for tryk-og-hold. Mere bekvemmeligt, men kan forårsage uhensigtede tryk.</string>
-    <string name="pref_snooze_interval_title">Snooze interval på påmindelser</string>
     <string name="pref_rate_this_app">Bedøm denne app på Google Play</string>
     <string name="pref_send_feedback">Send feedback til udvikleren</string>
     <string name="pref_view_source_code">Se kildekoden på GitHub</string>
     <string name="links">Henvisninger</string>
     <string name="name">Navn</string>
     <string name="settings">Indstillinger</string>
-    <string name="snooze_interval">Snooze interval</string>
     <string name="hint_title">Vidste du?</string>
     <string name="hint_drag">For at omarrangere poster, tryk og hold på navnet på den vane, og træk den til det korrekte sted.</string>
     <string name="hint_landscape">Du kan se flere dage ved at sætte telefonen i liggende tilstand.</string>

--- a/uhabits-android/src/main/res/values-de-rDE/strings.xml
+++ b/uhabits-android/src/main/res/values-de-rDE/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">Benutzerdeffiniert...</string>
     <string name="pref_toggle_title">Markierung durch kurzes Drücken ändern</string>
     <string name="pref_toggle_description">Markierungen durch einfaches Tippen setzen anstatt durch Tippen und Halten. Bequemer, kann aber versehentlich eine Markierung ändern.</string>
-    <string name="pref_snooze_interval_title">\"Später erinnern\"-Intervall bei Erinnerungen</string>
     <string name="pref_rate_this_app">Bewerte diese App auf Google Play</string>
     <string name="pref_send_feedback">Sende dem Entwickler Feedback</string>
     <string name="pref_view_source_code">Zeige den Quellcode auf GitHub</string>
     <string name="links">Links</string>
     <string name="name">Name</string>
     <string name="settings">Einstellungen</string>
-    <string name="snooze_interval">\"Später erinnern\"-Intervall</string>
     <string name="select_snooze_delay">Schlummer-Intervall auswählen</string>
     <string name="hint_title">Wusstest du?</string>
     <string name="hint_drag">Um Einträge umzusortieren, tippe, halte und ziehe sie an die richtige Stelle.</string>

--- a/uhabits-android/src/main/res/values-el-rGR/strings.xml
+++ b/uhabits-android/src/main/res/values-el-rGR/strings.xml
@@ -66,14 +66,12 @@
     <string name="interval_24_hour">24 Ωρο</string>
     <string name="pref_toggle_title">Κάντε εναλλαγή των επαναλήψεων με σύντομο πάτημα</string>
     <string name="pref_toggle_description">Βολικότερο, αλλά ίσως προκαλέσει ακούσιες εναλλαγές.</string>
-    <string name="pref_snooze_interval_title">Διάστημα αναβολής υπενθυμίσεων</string>
     <string name="pref_rate_this_app">Βαθμολογήστε αυτή την εφαρμογή στο Google Play</string>
     <string name="pref_send_feedback">Στείλετε σχόλια</string>
     <string name="pref_view_source_code">Δείτε τον πηγαίο κώδικα στο GitHub</string>
     <string name="links">Σύνδεσμοι</string>
     <string name="name">Όνομα</string>
     <string name="settings">Ρυθμίσεις</string>
-    <string name="snooze_interval">Διάστημα αναβολής</string>
     <string name="hint_title">Γνωρίζατε;</string>
     <string name="hint_drag">Αναδιατάξετε τις συνήθειες πατώντας παρατεταμένα στο όνομα και σύροντας στην σωστή θέση.</string>
     <string name="hint_landscape">Μπορείτε να δείτε περισσότερες ημέρες στην οριζόντια προβολή.</string>

--- a/uhabits-android/src/main/res/values-es-rES/strings.xml
+++ b/uhabits-android/src/main/res/values-es-rES/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">Personalizar...</string>
     <string name="pref_toggle_title">Marca las repeticiones con una pulsación corta</string>
     <string name="pref_toggle_description">Más cómodo, pero puede causar marcas accidentales.</string>
-    <string name="pref_snooze_interval_title">Tiempo de espera al aplazar recordatorios</string>
     <string name="pref_rate_this_app">Valora esta aplicación en Google Play</string>
     <string name="pref_send_feedback">Enviar sugerencias al desarrollador</string>
     <string name="pref_view_source_code">Ver código fuente en GitHub</string>
     <string name="links">Enlaces</string>
     <string name="name">Nombre</string>
     <string name="settings">Configuración</string>
-    <string name="snooze_interval">Intervalo de espera</string>
     <string name="select_snooze_delay">Seleccione el retardo de la interrupción</string>
     <string name="hint_title">¿Sabías qué?</string>
     <string name="hint_drag">Para reordenar las entradas, mantén la pulsado sobre el nombre del hábito, después arrástralo a su posición correcta.</string>

--- a/uhabits-android/src/main/res/values-eu-rES/strings.xml
+++ b/uhabits-android/src/main/res/values-eu-rES/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">Pertsonalizatua...</string>
     <string name="pref_toggle_title">Ukitze laburrarekin markatu</string>
     <string name="pref_toggle_description">Ukitze bakar batekin marka jartzen du ukitu eta mantendu egin beharrean. Erosoagoa, baina nahi gabeko markak ekar litzake.</string>
-    <string name="pref_snooze_interval_title">Atzeratze tartea oroigarrietan</string>
     <string name="pref_rate_this_app">Aplikazio hau Google Playen puntuatu</string>
     <string name="pref_send_feedback">Zure iritzia garatzaileari bidali</string>
     <string name="pref_view_source_code">Iturburu kodea GitHuben ikusi</string>
     <string name="links">Loturak</string>
     <string name="name">Izena</string>
     <string name="settings">Ezarpenak</string>
-    <string name="snooze_interval">Atzeratze tartea</string>
     <string name="select_snooze_delay">Aukeratu atzerapen denbora</string>
     <string name="hint_title">Ba al zenekien?</string>
     <string name="hint_drag">Sarrerak berrantolatzeko, sakatu eta mantendu ohituraren izena, ondoren mugi ezazu leku aproposera.</string>

--- a/uhabits-android/src/main/res/values-fa-rIR/strings.xml
+++ b/uhabits-android/src/main/res/values-fa-rIR/strings.xml
@@ -66,14 +66,12 @@
     <string name="interval_24_hour">۲۴ ساعت</string>
     <string name="pref_toggle_title">با اشاره‌ی کوتاه‌مدت وضعیت عادت را تغییر بده</string>
     <string name="pref_toggle_description">تیک زدن با تک‌ضربه در مقابل ضربه‌زدن و نگه‌داشتن راحت‌تر است ولی ممکن است باعث شود اشتباهی عادتی را تیک بزنید.</string>
-    <string name="pref_snooze_interval_title">بازه به تعویق انداختن یادآورها</string>
     <string name="pref_rate_this_app">به این برنامه در گوگل‌پلی امتیاز بدهید</string>
     <string name="pref_send_feedback">ارسال بازخورد به توسعه‌دهنده</string>
     <string name="pref_view_source_code">دیدن منبع برنامه در گیت‌هاب</string>
     <string name="links">لینک‌ها</string>
     <string name="name">نام</string>
     <string name="settings">تنظیمات</string>
-    <string name="snooze_interval">بازه به تعویق انداختن</string>
     <string name="hint_title">آیا می دانستید؟</string>
     <string name="hint_drag">برای جابجایی عناوین، انگشتتان را روی نام عادت مورد نظر بگذارید و نگه دارید، سپس آن را به محل صحیح بکشید.</string>
     <string name="hint_landscape">با قرار دادن گوشی در حالت افقی می‌توانید روزهای بیشتری را ببینید.</string>

--- a/uhabits-android/src/main/res/values-fr-rFR/strings.xml
+++ b/uhabits-android/src/main/res/values-fr-rFR/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">Personnaliser...</string>
     <string name="pref_toggle_title">Valider l\'habitude avec un appui court</string>
     <string name="pref_toggle_description">Valide l\'habitude avec un appui court plutôt qu\'un appuie long. Plus pratique, mais peut causer des activations accidentelles.</string>
-    <string name="pref_snooze_interval_title">Intervalle de report des rappels</string>
     <string name="pref_rate_this_app">Notez cette app sur le Google Play Store</string>
     <string name="pref_send_feedback">Envoyez un avis au développeur</string>
     <string name="pref_view_source_code">Voir le code source sur GitHub</string>
     <string name="links">Liens</string>
     <string name="name">Nom</string>
     <string name="settings">Paramètres</string>
-    <string name="snooze_interval">Intervalle de report</string>
     <string name="select_snooze_delay">Définir le délai de répétition</string>
     <string name="hint_title">Le saviez-vous ?</string>
     <string name="hint_drag">Pour réordonner les habitudes, faites un appui long sur le nom de l\'habitude et placez-la à la bonne place.</string>

--- a/uhabits-android/src/main/res/values-hi-rIN/strings.xml
+++ b/uhabits-android/src/main/res/values-hi-rIN/strings.xml
@@ -72,7 +72,6 @@
     <string name="pref_toggle_title">टॉगल पुनरावृत्ति  हल्का दबाने से</string>
     <string name="pref_toggle_description">\"
 अधिक सुविधाजनक है, लेकिन आकस्मिक टॉगल  हो सकता है ।\"</string>
-    <string name="pref_snooze_interval_title">रिमाइंडर मे स्नूज़ अंतराल</string>
     <string name="pref_rate_this_app">\"
 गूगले प्ले पर इस ऐप्लिकेशन को रेट करें\"</string>
     <string name="pref_send_feedback">डेवेलपर को प्रतिक्रिया भेजें </string>
@@ -80,8 +79,6 @@
     <string name="links">लिंक</string>
     <string name="name">नाम</string>
     <string name="settings">सेटिंग्स</string>
-    <string name="snooze_interval">\"
-झपकी का अंतराल\"</string>
     <string name="hint_title">क्या आप जानते .?</string>
     <string name="hint_drag">\"
 प्रविष्टियों को पुनर्व्यवस्थित करने के लिए, आदत के नाम पर प्रेस करें और सही जगह पर खींचें।\"</string>

--- a/uhabits-android/src/main/res/values-hr-rHR/strings.xml
+++ b/uhabits-android/src/main/res/values-hr-rHR/strings.xml
@@ -66,14 +66,12 @@
     <string name="interval_24_hour">24 sata</string>
     <string name="pref_toggle_title">Označi ponavljanja sa kratkim pritisk.</string>
     <string name="pref_toggle_description">Zgodnije je, no može uzrokovati slučajna označavanja.</string>
-    <string name="pref_snooze_interval_title">Interval odgađanja na podsjetnicima</string>
     <string name="pref_rate_this_app">Ocijeni ovu aplikaciju na Google Playu</string>
     <string name="pref_send_feedback">Pošalji povratne informacije raz. programeru</string>
     <string name="pref_view_source_code">Pogledaj izvorni kod na GitHubu</string>
     <string name="links">Poveznice</string>
     <string name="name">Naziv</string>
     <string name="settings">Postavke</string>
-    <string name="snooze_interval">Interval odgađanja</string>
     <string name="hint_title">Jeste li znali?</string>
     <string name="hint_drag">Za razmještanje unosa, pritisnite i držite naziv navike, pa ih premjestite na točno mjesto.</string>
     <string name="hint_landscape">Možete vidjeti više dana prebacivanjem uređaja u vodoravnu orijentaciju.</string>

--- a/uhabits-android/src/main/res/values-hu-rHU/strings.xml
+++ b/uhabits-android/src/main/res/values-hu-rHU/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">Egyedi...</string>
     <string name="pref_toggle_title">Bejelölés rövid koppintással</string>
     <string name="pref_toggle_description">Bejelölés koppintással nyomva tartás helyett. Kényelmesebb, de véletlen bejelöléseket okozhat.</string>
-    <string name="pref_snooze_interval_title">Szundi időtartama emlékeztetőnél</string>
     <string name="pref_rate_this_app">Értékeld az alkalmazást a Google Play-en</string>
     <string name="pref_send_feedback">Visszajelzés küldése a fejlesztőnek</string>
     <string name="pref_view_source_code">Forráskód megtekintése a GitHub-on</string>
     <string name="links">Linkek</string>
     <string name="name">Megnevezés</string>
     <string name="settings">Beállítások</string>
-    <string name="snooze_interval">Szundi időtartama</string>
     <string name="select_snooze_delay">Szundi beállítása</string>
     <string name="hint_title">Tudtad?</string>
     <string name="hint_drag">Az elemek újrarendezéséhez a koppints a szokás nevére, majd húzd a megfelelő helyre.</string>

--- a/uhabits-android/src/main/res/values-in-rID/strings.xml
+++ b/uhabits-android/src/main/res/values-in-rID/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">Kustom</string>
     <string name="pref_toggle_title">Tandai dengan cepat.</string>
     <string name="pref_toggle_description">Beri tanda cek dengan sekali ketuk bukan tekan-dan-tahan. Lebih nyaman, namun dapat menyebabkan kesalahan penandaan.</string>
-    <string name="pref_snooze_interval_title">Durasi tunda sejenak pada pengingat</string>
     <string name="pref_rate_this_app">Berikan rating aplikasi ini di Google Play</string>
     <string name="pref_send_feedback">Kirimkan umpan balik kepada Developer</string>
     <string name="pref_view_source_code">Lihat kode aplikasi di GitHub</string>
     <string name="links">Tautan</string>
     <string name="name">Nama</string>
     <string name="settings">Pengaturan</string>
-    <string name="snooze_interval">Durasi tunda sejenak</string>
     <string name="select_snooze_delay">Atur jeda penundaan</string>
     <string name="hint_title">Sudahkah Anda tahu?</string>
     <string name="hint_drag">Untuk mengatur urutan, tekan dan tahan judul Kebiasaan lalu tempatkan pada posisi yang Anda inginkan.</string>

--- a/uhabits-android/src/main/res/values-it-rIT/strings.xml
+++ b/uhabits-android/src/main/res/values-it-rIT/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">Personalizza...</string>
     <string name="pref_toggle_title">Spunta le ripetizioni velocemente</string>
     <string name="pref_toggle_description">Metti le spunte con un tocco singolo invece che tenendo premuto. Più comodo, ma potrebbe causare delle spunte accidentali.</string>
-    <string name="pref_snooze_interval_title">Intervallo di ritardo dei promemoria</string>
     <string name="pref_rate_this_app">Valuta quest\'app su Google Play</string>
     <string name="pref_send_feedback">Manda un feedback allo sviluppatore</string>
     <string name="pref_view_source_code">Vedi il codice sorgente su GitHub</string>
     <string name="links">Links</string>
     <string name="name">Nome</string>
     <string name="settings">Impostazioni</string>
-    <string name="snooze_interval">Snooze</string>
     <string name="select_snooze_delay">Seleziona ritardo posticipo</string>
     <string name="hint_title">Lo sapevi?</string>
     <string name="hint_drag">Per riordinare le voci, tieni premuto sul nome dell\'abitudine, poi spostala nella posizione corretta.</string>

--- a/uhabits-android/src/main/res/values-iw-rIL/strings.xml
+++ b/uhabits-android/src/main/res/values-iw-rIL/strings.xml
@@ -66,14 +66,12 @@
     <string name="interval_24_hour">24 שעות</string>
     <string name="pref_toggle_title">סימון הרגלים בלחיצה קצרה</string>
     <string name="pref_toggle_description">סמנו יעדים בהקשה קצרה במקום לחיצה ממושכת. נוח יותר, אך יכול להוביל ללחיצות לא מכוונות.</string>
-    <string name="pref_snooze_interval_title">מרווח נדנוד לתזכורות</string>
     <string name="pref_rate_this_app">דרג/י אותנו ב- Google Play</string>
     <string name="pref_send_feedback">שליחת משוב למפתחים</string>
     <string name="pref_view_source_code">צפייה בקוד המקור ב-GitHub</string>
     <string name="links">קישורים</string>
     <string name="name">שם</string>
     <string name="settings">הגדרות</string>
-    <string name="snooze_interval">זמן בין נדנודים</string>
     <string name="hint_title">הידעת?</string>
     <string name="hint_drag">לשינוי סדר הההרגלים, לחצו לחיצה ארוכה על ההרגל וגררו אותו למקום הרצוי.</string>
     <string name="hint_landscape">ניתן לראות ימים נוספים ע\"י סיבוב המסך לתצוגה רוחבית.</string>

--- a/uhabits-android/src/main/res/values-ja-rJP/strings.xml
+++ b/uhabits-android/src/main/res/values-ja-rJP/strings.xml
@@ -68,14 +68,12 @@
     <string name="interval_custom">カスタム...</string>
     <string name="pref_toggle_title">タップすると繰り返しを切り替えられます</string>
     <string name="pref_toggle_description">この機能は便利ですが、間違って切り替えが起こる可能性があります。</string>
-    <string name="pref_snooze_interval_title">リマインダーのスヌーズ間隔</string>
     <string name="pref_rate_this_app">Google Play でこのアプリを評価</string>
     <string name="pref_send_feedback">開発者にフィードバックを送信</string>
     <string name="pref_view_source_code">GitHub でソースコードを参照</string>
     <string name="links">リンク</string>
     <string name="name">タイトル</string>
     <string name="settings">設定</string>
-    <string name="snooze_interval">スヌーズ間隔</string>
     <string name="select_snooze_delay">スヌーズ遅延を設定</string>
     <string name="hint_title">ご存知ですか?</string>
     <string name="hint_drag">エントリーを並べ替えるには、習慣の名前を長押しして、正しい場所にドラッグしてください。</string>

--- a/uhabits-android/src/main/res/values-ko-rKR/strings.xml
+++ b/uhabits-android/src/main/res/values-ko-rKR/strings.xml
@@ -66,14 +66,12 @@
     <string name="interval_24_hour">24시간</string>
     <string name="pref_toggle_title">짧게 눌러서 전환하기</string>
     <string name="pref_toggle_description">길게 누르고 있는 대신에 짧은 탭 한 번으로 체크합니다. 더 편리하지만, 실수로 전환될 수도 있습니다.</string>
-    <string name="pref_snooze_interval_title">알림 스누즈 간격</string>
     <string name="pref_rate_this_app">Google Play에서 평가</string>
     <string name="pref_send_feedback">개발자에게 피드백 보내기</string>
     <string name="pref_view_source_code">Github에서 소스보기</string>
     <string name="links">링크</string>
     <string name="name">제목</string>
     <string name="settings">설정</string>
-    <string name="snooze_interval">스누즈 간격</string>
     <string name="hint_title">아시나요?</string>
     <string name="hint_drag">목록의 순서를 재배치하려면, 습관의 제목을 길게 누르고 다른 위치로 드래그하면 됩니다.</string>
     <string name="hint_landscape">가로 모드에서는 더 많은 날짜를 볼 수 있습니다.</string>

--- a/uhabits-android/src/main/res/values-nl-rNL/strings.xml
+++ b/uhabits-android/src/main/res/values-nl-rNL/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">Aangepast...</string>
     <string name="pref_toggle_title">Wijzig herhalingen door kort indrukken</string>
     <string name="pref_toggle_description">Zet vinkjes met een enkel tikje in plaats van ingedrukt houden. Handiger, maar kan onbedoelde wijzigingen veroorzaken.</string>
-    <string name="pref_snooze_interval_title">Snooze interval voor herinneringen</string>
     <string name="pref_rate_this_app">Beoordeel deze app in Google Play</string>
     <string name="pref_send_feedback">Stuur feedback aan de ontwikkelaar</string>
     <string name="pref_view_source_code">Bekijk de broncode op GitHub</string>
     <string name="links">Links</string>
     <string name="name">Naam</string>
     <string name="settings">Instellingen</string>
-    <string name="snooze_interval">Snooze interval</string>
     <string name="select_snooze_delay">Snooze vertraging selecteren</string>
     <string name="hint_title">Wist je dat?</string>
     <string name="hint_drag">Om de rijen te ordenen, houdt de gewoonte ingedrukt en sleep het naar de gewenste plek.</string>

--- a/uhabits-android/src/main/res/values-no-rNO/strings.xml
+++ b/uhabits-android/src/main/res/values-no-rNO/strings.xml
@@ -66,14 +66,12 @@
     <string name="interval_24_hour">1 døgn</string>
     <string name="pref_toggle_title">Veksl med enkelttrykk</string>
     <string name="pref_toggle_description">Sett på haker med et enkelttrykk i stedet for å tykke og holde. Mer praktisk, men kan forårsake utilsiktede vekslinger.</string>
-    <string name="pref_snooze_interval_title">Slumreintervall på påminnelser</string>
     <string name="pref_rate_this_app">Vurdér denne appen på Google Play</string>
     <string name="pref_send_feedback">Send tilbakemelding til utviklerne</string>
     <string name="pref_view_source_code">Vis kildekode på GitHub</string>
     <string name="links">Lenker</string>
     <string name="name">Navn</string>
     <string name="settings">Innstillinger</string>
-    <string name="snooze_interval">Slumreintervall</string>
     <string name="hint_title">Visste du at?</string>
     <string name="hint_drag">For å sortere innleggene, trykk og hold på navnet til vanen, deretter dra den til det korrekte stedet.</string>
     <string name="hint_landscape">Du kan se flere dager ved å sette telefonen din i landskapsmodus.</string>

--- a/uhabits-android/src/main/res/values-pl-rPL/strings.xml
+++ b/uhabits-android/src/main/res/values-pl-rPL/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">Niestandardowe...</string>
     <string name="pref_toggle_title">Przełącz powtarzanie krótkim naciśnięciem</string>
     <string name="pref_toggle_description">Wygodniejsze, ale może spowodować przypadkowe przełączenia.</string>
-    <string name="pref_snooze_interval_title">Czas drzemki między przypomnieniami</string>
     <string name="pref_rate_this_app">Oceń tę aplikację w Google Play</string>
     <string name="pref_send_feedback">Prześlij uwagi do programisty</string>
     <string name="pref_view_source_code">Zobacz kod źródłowy na GitHub\'ie</string>
     <string name="links">Linki</string>
     <string name="name">Nazwa</string>
     <string name="settings">Ustawienia</string>
-    <string name="snooze_interval">Czas drzemki</string>
     <string name="select_snooze_delay">Wybierz długość drzemki</string>
     <string name="hint_title">Czy wiesz że?</string>
     <string name="hint_drag">Aby zmienić kolejność naciśnij i przytrzymaj na nazwie nawyku i przesuń go na odpowiednie miejsce.</string>

--- a/uhabits-android/src/main/res/values-pt-rBR/strings.xml
+++ b/uhabits-android/src/main/res/values-pt-rBR/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">Personalizar...</string>
     <string name="pref_toggle_title">Marcar repetições com um toque curto</string>
     <string name="pref_toggle_description">Mais conveniente, mas pode causar marcações acidentais</string>
-    <string name="pref_snooze_interval_title">Duração do \"mais tarde\" nos lembretes</string>
     <string name="pref_rate_this_app">Avaliar esse app no Google Play</string>
     <string name="pref_send_feedback">Mandar sugestões para o desenvolvedor</string>
     <string name="pref_view_source_code">Ver código-fonte no GitHub</string>
     <string name="links">Links</string>
     <string name="name">Nome</string>
     <string name="settings">Configurações</string>
-    <string name="snooze_interval">Duração do \"mais tarde\"</string>
     <string name="select_snooze_delay">Selecionar duração do \"mais tarde\"</string>
     <string name="hint_title">Dica</string>
     <string name="hint_drag">Para mudar a ordem dos hábitos, aperte no nome do hábito, sustente e arraste.</string>

--- a/uhabits-android/src/main/res/values-pt-rPT/strings.xml
+++ b/uhabits-android/src/main/res/values-pt-rPT/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">Personalizar...</string>
     <string name="pref_toggle_title">Toque para alternar entre repetições</string>
     <string name="pref_toggle_description">Mais conveniente, mas pode causar toques acidentais</string>
-    <string name="pref_snooze_interval_title">Intervalo da opção \'Mais Tarde\' nos lembretes</string>
     <string name="pref_rate_this_app">Avaliar a app no Google Play</string>
     <string name="pref_send_feedback">Enviar feedback ao programador</string>
     <string name="pref_view_source_code">Ver código-fonte no GitHub</string>
     <string name="links">Hiperligações</string>
     <string name="name">Nome</string>
     <string name="settings">Definições</string>
-    <string name="snooze_interval">Intervalo da opção \'Mais Tarde\'</string>
     <string name="select_snooze_delay">Definir tempo de suspensão</string>
     <string name="hint_title">Sabia que?</string>
     <string name="hint_drag">Para reorganizar a lista, mantenha pressionado o nome do hábito e arraste-o para o lugar certo.</string>

--- a/uhabits-android/src/main/res/values-ro-rRO/strings.xml
+++ b/uhabits-android/src/main/res/values-ro-rRO/strings.xml
@@ -66,14 +66,12 @@
     <string name="interval_24_hour">24 de ore</string>
     <string name="pref_toggle_title">Comută repetițiile printr-o apăsare scurtă</string>
     <string name="pref_toggle_description">Mai convenabil, dar poate cauza comutări accidentale.</string>
-    <string name="pref_snooze_interval_title">Intervalul de amânare al atenționării</string>
     <string name="pref_rate_this_app">Evaluează aplicația pe Magazin Play</string>
     <string name="pref_send_feedback">Trimite păreri dezvoltatorului</string>
     <string name="pref_view_source_code">Vezi codul sursă pe GitHub</string>
     <string name="links">Aplicație</string>
     <string name="name">Nume</string>
     <string name="settings">Setări</string>
-    <string name="snooze_interval">Intervalul de amânare</string>
     <string name="hint_title">Știai?</string>
     <string name="hint_drag">Pentru a rearanja obiceiurile, apasă și ține numele obiceiului, apoi trage-l în locul corect.</string>
     <string name="hint_landscape">Poți vedea mai multe zile în modul peisaj.</string>

--- a/uhabits-android/src/main/res/values-ru-rRU/strings.xml
+++ b/uhabits-android/src/main/res/values-ru-rRU/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">Настроить...</string>
     <string name="pref_toggle_title">Отмечать коротким нажатием</string>
     <string name="pref_toggle_description">Ставить галочки коротким нажатием вместо удержания. Удобнее, но может стать причиной случайных отметок.</string>
-    <string name="pref_snooze_interval_title">Интервал откладывания напоминаний</string>
     <string name="pref_rate_this_app">Оценить приложение в Google Play</string>
     <string name="pref_send_feedback">Отправить сообщение разработчику</string>
     <string name="pref_view_source_code">Посмотреть исходный код на GitHub</string>
     <string name="links">Ссылки</string>
     <string name="name">Название</string>
     <string name="settings">Настройки</string>
-    <string name="snooze_interval">Интервал откладывания</string>
     <string name="select_snooze_delay">Задержка повтора</string>
     <string name="hint_title">А вы знали?</string>
     <string name="hint_drag">Чтобы поменять порядок записей, нажмите и удерживайте название записи, затем перетащите её на нужное место.</string>

--- a/uhabits-android/src/main/res/values-sk-rSK/strings.xml
+++ b/uhabits-android/src/main/res/values-sk-rSK/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">Vlastné ...</string>
     <string name="pref_toggle_title">Prepnúť krátkym stlačením</string>
     <string name="pref_toggle_description">Pridajte začiarknutie jediným klepnutím namiesto stlačenia a podržania. Je to pohodlnejšie, ale môže dôjsť k náhodným prepnutiam.</string>
-    <string name="pref_snooze_interval_title">Interval odloženia pripomienok</string>
     <string name="pref_rate_this_app">Ohodnoťte túto aplikáciu na Google Play</string>
     <string name="pref_send_feedback">Odošlite spätnú väzbu vývojárovi</string>
     <string name="pref_view_source_code">Zobraziť zdrojový kód na stránke GitHub</string>
     <string name="links">Odkazy</string>
     <string name="name">Názov</string>
     <string name="settings">Nastavenia</string>
-    <string name="snooze_interval">Interval odloženia</string>
     <string name="select_snooze_delay">Nastaviť dĺžku odloženia</string>
     <string name="hint_title">Vedeli ste?</string>
     <string name="hint_drag">Pre zmenu usporiadania záznamov, stlačte a podržte názov návyku a potom ho presuňte na správne miesto.</string>

--- a/uhabits-android/src/main/res/values-sl-rSI/strings.xml
+++ b/uhabits-android/src/main/res/values-sl-rSI/strings.xml
@@ -66,14 +66,12 @@
     <string name="interval_24_hour">24 ur</string>
     <string name="pref_toggle_title">Preklopi ponovitve s kratkim pritiskom</string>
     <string name="pref_toggle_description">Bolj priročno ampak lahko povzroči nenamerne preklapljanje.</string>
-    <string name="pref_snooze_interval_title">Interval dremeža na opomnikih</string>
     <string name="pref_rate_this_app">Oceni to aplikacijo na Google Play</string>
     <string name="pref_send_feedback">Pošlji povratne informacije razvijalcem</string>
     <string name="pref_view_source_code">Poglej izvorno kodo na GitHub</string>
     <string name="links">Povezave</string>
     <string name="name">Ime</string>
     <string name="settings">Nastavitve</string>
-    <string name="snooze_interval">Interval dremeža</string>
     <string name="hint_title">Ali ste vedeli?</string>
     <string name="hint_drag">Če želite preurediti vnose, pritisnite-in-držite na ime navade, nato pa jo povlecite na željeno mestu.</string>
     <string name="hint_landscape">Ogledate si lahko več dni, s tem da telefon postavite v ležeči načinu.</string>

--- a/uhabits-android/src/main/res/values-sr-rSP/strings.xml
+++ b/uhabits-android/src/main/res/values-sr-rSP/strings.xml
@@ -65,14 +65,12 @@
     <string name="interval_8_hour">8 сати</string>
     <string name="pref_toggle_title">Маркирај кратким додиром</string>
     <string name="pref_toggle_description">Практичније, али може доћи до случајног маркирања.</string>
-    <string name="pref_snooze_interval_title">Одлагање подсетника</string>
     <string name="pref_rate_this_app">Оцени апликацију</string>
     <string name="pref_send_feedback">Повратне информације</string>
     <string name="pref_view_source_code">Изворни кôд на GitHub-у</string>
     <string name="links">Везе</string>
     <string name="name">Име</string>
     <string name="settings">Поставке</string>
-    <string name="snooze_interval">Време одлагања</string>
     <string name="hint_title">Да ли сте знали?</string>
     <string name="hint_drag">Притисните и држите име навике да бисте је прераспоредили.</string>
     <string name="hint_landscape">Положите уређај да бисте видели више дана.</string>

--- a/uhabits-android/src/main/res/values-sv-rSE/strings.xml
+++ b/uhabits-android/src/main/res/values-sv-rSE/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">Anpassad...</string>
     <string name="pref_toggle_title">Växla med snabb tryckning</string>
     <string name="pref_toggle_description">Markera genom att trycka snabbt istället för att hålla ner. Mer bekvämt, men kan orsaka oavsiktliga aktiveringar.</string>
-    <string name="pref_snooze_interval_title">Standard tid på snooze</string>
     <string name="pref_rate_this_app">Betygsätt oss på Google Play</string>
     <string name="pref_send_feedback">Skicka feedback till utvecklarna</string>
     <string name="pref_view_source_code">Visa källkod på GitHub</string>
     <string name="links">Länkar</string>
     <string name="name">Namn</string>
     <string name="settings">Inställningar</string>
-    <string name="snooze_interval">Intervall snooze</string>
     <string name="select_snooze_delay">Välj snoozelängd</string>
     <string name="hint_title">Visste du att?</string>
     <string name="hint_drag">För att flytta på poster - tryck och håll nere på den vana du vill flytta, sedan flytta den till önskad plats.</string>

--- a/uhabits-android/src/main/res/values-ta-rIN/strings.xml
+++ b/uhabits-android/src/main/res/values-ta-rIN/strings.xml
@@ -66,14 +66,12 @@
     <string name="interval_24_hour">24 மணி நேரம்</string>
     <string name="pref_toggle_title">சிறிய அழுத்தலின் மூலம் தாவு</string>
     <string name="pref_toggle_description">சரிப் பார்ப்பு குறி யை இட அழுத்தி பிடிப்பதற்கு பதில் ஒரு முறை தட்டலாம். இது முன்னதை விட எளிமையானது. ஆனால் இது தற்செயலான தாவல்களுக்கு வழி வகுக்கும்.</string>
-    <string name="pref_snooze_interval_title">எச்சரிகையை தள்ளி வைக்க வேண்டிய நேரம்</string>
     <string name="pref_rate_this_app">Google Play-ல் இந்த செயலியை மதிப்பிட</string>
     <string name="pref_send_feedback">இந்த செயலியை மேம்படுத்த உங்கள் கருத்துகளை பகிர</string>
     <string name="pref_view_source_code">இந்த செயலியின் மூல நிரலை GitHub வலைதளத்தில் பார்க்கவும்</string>
     <string name="links">இணைப்புகள்</string>
     <string name="name">பெயர்</string>
     <string name="settings">அமைப்புகள்</string>
-    <string name="snooze_interval">தாமத காலம்</string>
     <string name="hint_title">உங்களுக்கு தெரியுமா?</string>
     <string name="hint_drag">பதிவுகளை மறுசீரைமக்க, தேவையான பழக்க பதிவின் மீது அழுத்தி பிடித்து பின் தேவையான இடத்திற்கு அதை இழுக்கவும்.</string>
     <string name="hint_landscape">உங்கள் கைப்பேசியை அகலவாக்கில் வைக்கும்போது இன்னும் அதிக நாட்களை காண முடியும்.</string>

--- a/uhabits-android/src/main/res/values-tr-rTR/strings.xml
+++ b/uhabits-android/src/main/res/values-tr-rTR/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">Özel...</string>
     <string name="pref_toggle_title">Tek dokunuşla işaretle veya işareti kaldır</string>
     <string name="pref_toggle_description">Alışkanlıklarınızı, uzun dokunuş yerine tek dokunuşla işaretlemenizi sağlar. Kullanımı daha kolaydır ancak hatalı olarak işaretleme yapılmasına neden olabilir.</string>
-    <string name="pref_snooze_interval_title">Hatırlatmalardaki erteleme süresi</string>
     <string name="pref_rate_this_app">Google Play\'de uygulamayı oyla</string>
     <string name="pref_send_feedback">Geliştiriciye geri bildirim gönder</string>
     <string name="pref_view_source_code">Github\'da kaynak kodunu gör</string>
     <string name="links">Bağlantılar</string>
     <string name="name">Ad</string>
     <string name="settings">Ayarlar</string>
-    <string name="snooze_interval">Erteleme süresi</string>
     <string name="select_snooze_delay">Erteleme süresini ayarla</string>
     <string name="hint_title">Biliyor muydun?</string>
     <string name="hint_drag">Girdileri sıralamak için, alışkanlık adının üstüne basılı tut ve doğru yere sürükle.</string>

--- a/uhabits-android/src/main/res/values-uk-rUA/strings.xml
+++ b/uhabits-android/src/main/res/values-uk-rUA/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">Налаштувати...</string>
     <string name="pref_toggle_title">Відзначати коротким натисканням</string>
     <string name="pref_toggle_description">Ставити пташки коротким натисканням, замість утримування. Дещо зручніше, але може стати причиною випадкових натискань.</string>
-    <string name="pref_snooze_interval_title">Час відкладення нагадувань</string>
     <string name="pref_rate_this_app">Оцінити цю програму в Google Play</string>
     <string name="pref_send_feedback">Надіслати відгук розробникові</string>
     <string name="pref_view_source_code">Подивитися вихідний код на GitHub</string>
     <string name="links">Посилання</string>
     <string name="name">Назва</string>
     <string name="settings">Налаштування</string>
-    <string name="snooze_interval">Час відкладення</string>
     <string name="select_snooze_delay">Встановити повторне нагадування</string>
     <string name="hint_title">Чи знаете ви, що?</string>
     <string name="hint_drag">Аби змінити порядок записів, натисніть і утримуйте назву запису, опісля перетягніть запис на потрібне місце.</string>

--- a/uhabits-android/src/main/res/values-vi-rVN/strings.xml
+++ b/uhabits-android/src/main/res/values-vi-rVN/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">Tùy chỉnh...</string>
     <string name="pref_toggle_title">Bấm nhanh để chuyển trạng thái</string>
     <string name="pref_toggle_description">Chỉ cần chạm một lần để đánh dấu thay cho việc nhấn giữ. Tiện lợi hơn nhưng có thể đánh dấu sai.</string>
-    <string name="pref_snooze_interval_title">Khoảng thời gian báo lại lời nhắc</string>
     <string name="pref_rate_this_app">Đánh giá ứng dụng trên Google Play</string>
     <string name="pref_send_feedback">Gửi phản hồi cho nhà phát triển</string>
     <string name="pref_view_source_code">Xem mã nguồn trên Github</string>
     <string name="links">Liên kết</string>
     <string name="name">Tên</string>
     <string name="settings">Cài đặt</string>
-    <string name="snooze_interval">Khoảng thời gian tạm dừng</string>
     <string name="select_snooze_delay">Chọn độ trễ báo lại</string>
     <string name="hint_title">Bạn đã biết?</string>
     <string name="hint_drag">Để sắp xếp lại các mục, nhấn giữ tên thói quen, sau đó kéo tới vị trí chính xác.</string>

--- a/uhabits-android/src/main/res/values-zh-rCN/strings.xml
+++ b/uhabits-android/src/main/res/values-zh-rCN/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">自定义</string>
     <string name="pref_toggle_title">轻触以启动重复</string>
     <string name="pref_toggle_description">更加方便，但有可能造成意外记录</string>
-    <string name="pref_snooze_interval_title">提醒延迟间隔</string>
     <string name="pref_rate_this_app">去Play商店评价这个应用</string>
     <string name="pref_send_feedback">发送反馈给开发者</string>
     <string name="pref_view_source_code">在Github上查看源代码</string>
     <string name="links">链接</string>
     <string name="name">习惯标题</string>
     <string name="settings">设置</string>
-    <string name="snooze_interval">推迟提醒间隔</string>
     <string name="select_snooze_delay">设定暂停提醒的重复时间</string>
     <string name="hint_title">你知道吗？</string>
     <string name="hint_drag">如果要重新排列习惯，按住习惯的名字拖到想要的位置</string>

--- a/uhabits-android/src/main/res/values-zh-rTW/strings.xml
+++ b/uhabits-android/src/main/res/values-zh-rTW/strings.xml
@@ -64,14 +64,12 @@
     <string name="interval_custom">自訂</string>
     <string name="pref_toggle_title">換成輕碰來記錄習慣</string>
     <string name="pref_toggle_description">雖然更方便，但有可能變成不小心就點到</string>
-    <string name="pref_snooze_interval_title">延後提醒的間隔</string>
     <string name="pref_rate_this_app">在 Google Play 上評價這個 App</string>
     <string name="pref_send_feedback">傳送改進意見給開發者</string>
     <string name="pref_view_source_code">在 GitHub 上查看原始碼</string>
     <string name="links">連結</string>
     <string name="name">習慣名稱</string>
     <string name="settings">偏好設定</string>
-    <string name="snooze_interval">延後時間間隔</string>
     <string name="select_snooze_delay">選擇延後通知</string>
     <string name="hint_title">你知道嗎？</string>
     <string name="hint_drag">如果要重新排列習慣，可以將其拖曳到理想的位置</string>

--- a/uhabits-android/src/main/res/values/constants.xml
+++ b/uhabits-android/src/main/res/values/constants.xml
@@ -29,28 +29,6 @@
     <string name="bugReportSubject">Bug Report - Loop Habit Tracker</string>
     <string name="syncBaseURL" formatted="false">https://sync.loophabits.org</string>
 
-    <string-array name="snooze_interval_names">
-        <item>@string/interval_15_minutes</item>
-        <item>@string/interval_30_minutes</item>
-        <item>@string/interval_1_hour</item>
-        <item>@string/interval_2_hour</item>
-        <item>@string/interval_4_hour</item>
-        <item>@string/interval_8_hour</item>
-        <item>@string/interval_24_hour</item>
-        <item>@string/interval_always_ask</item>
-    </string-array>
-
-    <string-array name="snooze_interval_values" translatable="false">
-        <item>15</item>
-        <item>30</item>
-        <item>60</item>
-        <item>120</item>
-        <item>240</item>
-        <item>480</item>
-        <item>1440</item>
-        <item>-1</item>
-    </string-array>
-
     <string-array name="snooze_picker_names">
         <item>@string/interval_15_minutes</item>
         <item>@string/interval_30_minutes</item>
@@ -98,8 +76,6 @@
         <item>@string/quarter</item>
         <item>@string/year</item>
     </string-array>
-
-    <string name="snooze_interval_default" translatable="false">15</string>
 
     <string-array name="widget_opacity_entries">
         <item>100%</item>

--- a/uhabits-android/src/main/res/values/strings.xml
+++ b/uhabits-android/src/main/res/values/strings.xml
@@ -82,14 +82,12 @@
     <string name="interval_custom">Custom...</string>
     <string name="pref_toggle_title">Toggle with short press</string>
     <string name="pref_toggle_description">Put checkmarks with a single tap instead of press-and-hold. More convenient, but might cause accidental toggles.</string>
-    <string name="pref_snooze_interval_title">Snooze interval on reminders</string>
     <string name="pref_rate_this_app">Rate this app on Google Play</string>
     <string name="pref_send_feedback">Send feedback to developer</string>
     <string name="pref_view_source_code">View source code at GitHub</string>
     <string name="links">Links</string>
     <string name="name">Name</string>
     <string name="settings">Settings</string>
-    <string name="snooze_interval">Snooze interval</string>
     <string name="select_snooze_delay">Select snooze delay</string>
     <string name="hint_title">Did you know?</string>
     <string name="hint_drag">To rearrange the entries, press-and-hold on the name of the habit, then drag it to the correct place.</string>

--- a/uhabits-android/src/main/res/xml/preferences.xml
+++ b/uhabits-android/src/main/res/xml/preferences.xml
@@ -87,16 +87,6 @@
             android:key="reminderCategory"
             android:title="@string/reminder">
 
-        <ListPreference
-                android:defaultValue="@string/snooze_interval_default"
-                android:dialogTitle="@string/snooze_interval"
-                android:entries="@array/snooze_interval_names"
-                android:entryValues="@array/snooze_interval_values"
-                android:key="pref_snooze_interval"
-                android:summary="%s"
-                android:title="@string/pref_snooze_interval_title"
-                app:iconSpaceReserved="false" />
-
         <Preference
                 android:key="reminderSound"
                 android:title="@string/reminder_sound"

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/preferences/Preferences.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/preferences/Preferences.kt
@@ -101,12 +101,6 @@ open class Preferences(private val storage: Storage) {
         set(showCompleted) {
             storage.putBoolean("pref_show_completed", showCompleted)
         }
-    val snoozeInterval: Long
-        get() = storage.getString("pref_snooze_interval", "15").toLong()
-
-    fun setSnoozeInterval(interval: Int) {
-        storage.putString("pref_snooze_interval", interval.toString())
-    }
 
     var theme: Int
         get() = storage.getInt("pref_theme", ThemeSwitcher.THEME_AUTOMATIC)

--- a/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/preferences/PreferencesTest.kt
+++ b/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/preferences/PreferencesTest.kt
@@ -119,9 +119,6 @@ class PreferencesTest : BaseUnitTest() {
         assertFalse(prefs.shouldMakeNotificationsLed())
         prefs.setNotificationsLed(true)
         assertTrue(prefs.shouldMakeNotificationsLed())
-        assertThat(prefs.snoozeInterval, equalTo(15L))
-        prefs.setSnoozeInterval(30)
-        assertThat(prefs.snoozeInterval, equalTo(30L))
     }
 
     @Test


### PR DESCRIPTION
For devices older than Android Oreo, notification sound customization has been
disabled since aadfac68cd5872209c4313ccca4f7a1f6101c9ea. We enable it again.

Fixes #766.

I assume there's more to it than I've understood given your comment `Temporarily disable this; we now always ask`, let me know what I'm missing!