### PR TITLE
Update X contrast color to medium to improve readability.

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/CheckmarkButtonView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/CheckmarkButtonView.kt
@@ -116,7 +116,7 @@ class CheckmarkButtonView(
 
     private inner class Drawer {
         private val rect = RectF()
-        private val lowContrastColor = sres.getColor(R.attr.lowContrastTextColor)
+        private val medContrastColor = sres.getColor(R.attr.mediumContrastTextColor)
 
         private val paint = TextPaint().apply {
             typeface = getFontAwesome()
@@ -129,7 +129,7 @@ class CheckmarkButtonView(
             paint.color = when (value) {
                 YES_MANUAL -> color
                 SKIP -> color
-                else -> lowContrastColor
+                else -> medContrastColor
             }
             val id = when (value) {
                 SKIP -> R.string.fa_skipped


### PR DESCRIPTION
This is a PR to handle issue mentioned in 
* [issue #719](https://github.com/iSoron/uhabits/issues/719)
* [issue #649](https://github.com/iSoron/uhabits/discussions/649)
* [Issue #413](https://github.com/iSoron/uhabits/discussions/413)

I debated a few solutions like a ternary operator to up contrast on dark mode only but this solves the issue and while I don't use light mode frequently, the improved contrast is nicer there too.

### Light Mode Example
![image](https://user-images.githubusercontent.com/19443973/107160348-8e403100-694a-11eb-903f-eaa89dfaafae.png)
### Dark Mode Example
![image](https://user-images.githubusercontent.com/19443973/107160357-9c8e4d00-694a-11eb-8ae9-7c6cafd01b93.png)
