### PR TITLE
Make validation errors readable

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/edit/EditHabitActivity.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/edit/EditHabitActivity.kt
@@ -23,15 +23,22 @@ import android.annotation.SuppressLint
 import android.content.res.ColorStateList
 import android.graphics.Color
 import android.os.Bundle
+import android.text.Html
+import android.text.Spanned
 import android.text.format.DateFormat
 import android.view.View
 import android.widget.ArrayAdapter
+import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.DialogFragment
 import com.android.datetimepicker.time.RadialPickerLayout
 import com.android.datetimepicker.time.TimePickerDialog
-import kotlinx.android.synthetic.main.activity_edit_habit.*
+import kotlinx.android.synthetic.main.activity_edit_habit.nameInput
+import kotlinx.android.synthetic.main.activity_edit_habit.notesInput
+import kotlinx.android.synthetic.main.activity_edit_habit.questionInput
+import kotlinx.android.synthetic.main.activity_edit_habit.targetInput
+import kotlinx.android.synthetic.main.activity_edit_habit.unitInput
 import org.isoron.uhabits.HabitsApplication
 import org.isoron.uhabits.R
 import org.isoron.uhabits.activities.AndroidThemeSwitcher
@@ -264,12 +271,12 @@ class EditHabitActivity : AppCompatActivity() {
     private fun validate(): Boolean {
         var isValid = true
         if (nameInput.text.isEmpty()) {
-            nameInput.error = getString(R.string.validation_cannot_be_blank)
+            nameInput.error = getFormattedValidationError(R.string.validation_cannot_be_blank)
             isValid = false
         }
         if (habitType == Habit.NUMBER_HABIT) {
             if (unitInput.text.isEmpty()) {
-                unitInput.error = getString(R.string.validation_cannot_be_blank)
+                unitInput.error = getFormattedValidationError(R.string.validation_cannot_be_blank)
                 isValid = false
             }
             if (targetInput.text.isEmpty()) {
@@ -320,6 +327,11 @@ class EditHabitActivity : AppCompatActivity() {
             window.statusBarColor = darkerAndroidColor
             binding.toolbar.setBackgroundColor(androidColor)
         }
+    }
+
+    private fun getFormattedValidationError(@StringRes resId: Int): Spanned {
+        val html = "<font color=#FFFFFF>${getString(resId)}</font>"
+        return Html.fromHtml(html)
     }
 
     override fun onSaveInstanceState(state: Bundle) {


### PR DESCRIPTION
Fixes #757.

I felt that was not the way, which is why I thought I'd only give a few hints there: https://github.com/iSoron/uhabits/issues/757#issuecomment-779245103

But revisiting this now I'm under the impression that the only proper way to do things would be to migrate to TextInputLayout and follow the guide there: https://material.io/components/text-fields/android#outlined-text-field

Maybe you'll find this trivial and quick to do, but I didn't, hence this quick-and-dirty fix.