### PR TITLE
Start snooze activity after later is selected from lock screen

### DIFF
--- a/uhabits-android/src/main/AndroidManifest.xml
+++ b/uhabits-android/src/main/AndroidManifest.xml
@@ -148,6 +148,7 @@
 
         <activity
             android:name=".notifications.SnoozeDelayPickerActivity"
+            android:taskAffinity=""
             android:excludeFromRecents="true"
             android:launchMode="singleInstance"
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />

--- a/uhabits-android/src/main/java/org/isoron/uhabits/notifications/SnoozeDelayPickerActivity.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/notifications/SnoozeDelayPickerActivity.kt
@@ -61,7 +61,6 @@ class SnoozeDelayPickerActivity : FragmentActivity(), OnItemClickListener {
             .setItems(R.array.snooze_picker_names, null)
             .create()
         dialog!!.listView.onItemClickListener = this
-        dialog!!.setOnDismissListener { finish() }
         dialog!!.show()
         SystemUtils.unlockScreen(this)
     }
@@ -94,8 +93,14 @@ class SnoozeDelayPickerActivity : FragmentActivity(), OnItemClickListener {
         overridePendingTransition(0, 0)
     }
 
+    override fun onResume() {
+        SystemUtils.unlockScreen(this)
+        super.onResume()
+        if (dialog != null) dialog!!.show()
+    }
+
     override fun onPause() {
-        if (dialog != null) dialog!!.dismiss()
         super.onPause()
+        if (dialog != null) dialog!!.dismiss()
     }
 }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/notifications/SnoozeDelayPickerActivity.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/notifications/SnoozeDelayPickerActivity.kt
@@ -61,6 +61,7 @@ class SnoozeDelayPickerActivity : FragmentActivity(), OnItemClickListener {
             .setItems(R.array.snooze_picker_names, null)
             .create()
         dialog!!.listView.onItemClickListener = this
+        dialog!!.setOnDismissListener { finish() }
         dialog!!.show()
         SystemUtils.unlockScreen(this)
     }
@@ -91,16 +92,5 @@ class SnoozeDelayPickerActivity : FragmentActivity(), OnItemClickListener {
     override fun finish() {
         super.finish()
         overridePendingTransition(0, 0)
-    }
-
-    override fun onResume() {
-        SystemUtils.unlockScreen(this)
-        super.onResume()
-        if (dialog != null) dialog!!.show()
-    }
-
-    override fun onPause() {
-        super.onPause()
-        if (dialog != null) dialog!!.dismiss()
     }
 }


### PR DESCRIPTION
Fixes #787.

This seems to fix it, but honestly I'm not aware of the full implications, and I haven't tested it enough to be confident that it doesn't introduce other bugs. So help appreciated, otherwise if it points you in the right direction for a proper fix that's good enough for me!

The change in the manifest might or might not be needed (I have tested only with it), but I think the doc says it should be like this:
https://developer.android.com/training/notify-user/navigation#ExtendedNotification

Leaving it as a draft for now (since I don't think it's ready to merge as-is), but I would likely need help to make further progress.