### PR TITLE
Add setting for higher contrast task symbols

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/CheckmarkButtonView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/CheckmarkButtonView.kt
@@ -117,6 +117,7 @@ class CheckmarkButtonView(
     private inner class Drawer {
         private val rect = RectF()
         private val lowContrastColor = sres.getColor(R.attr.lowContrastTextColor)
+        private val medContrastColor = sres.getColor(R.attr.mediumContrastTextColor)
 
         private val paint = TextPaint().apply {
             typeface = getFontAwesome()
@@ -129,7 +130,10 @@ class CheckmarkButtonView(
             paint.color = when (value) {
                 YES_MANUAL -> color
                 SKIP -> color
-                else -> lowContrastColor
+                else -> {
+                    if (preferences.isHigherContrastEnabled()) medContrastColor
+                    else lowContrastColor
+                }
             }
             val id = when (value) {
                 SKIP -> R.string.fa_skipped

--- a/uhabits-android/src/main/res/values/strings.xml
+++ b/uhabits-android/src/main/res/values/strings.xml
@@ -237,6 +237,8 @@
     <string name="sync_key_already_installed">Sync key already installed</string>
     <string name="pref_unknown_title">Show question marks for missing data</string>
     <string name="pref_unknown_description">Differentiate days without data from actual lapses. To enter a lapse, toggle twice.</string>
+    <string name="pref_higher_contrast_title">Use higher contrast for symbols</string>
+    <string name="pref_higher_contrast_description">Task progress symbols will use a higher contrast font color.</string>
     <string name="you_are_now_a_developer">You are now a developer</string>
     <string name="activity_not_found">No app was found to support this action</string>
     <string name="pref_midnight_delay_title">Extend day a few hours past midnight</string>

--- a/uhabits-android/src/main/res/xml/preferences.xml
+++ b/uhabits-android/src/main/res/xml/preferences.xml
@@ -53,6 +53,13 @@
             app:iconSpaceReserved="false" />
 
         <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="pref_higher_contrast_enabled"
+            android:summary="@string/pref_higher_contrast_description"
+            android:title="@string/pref_higher_contrast_title"
+            app:iconSpaceReserved="false" />
+
+        <CheckBoxPreference
                 android:defaultValue="false"
                 android:key="pref_checkmark_reverse_order"
                 android:summary="@string/reverse_days_description"

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/preferences/Preferences.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/preferences/Preferences.kt
@@ -230,6 +230,10 @@ open class Preferences(private val storage: Storage) {
         return storage.getBoolean("pref_unknown_enabled", false)
     }
 
+    fun isHigherContrastEnabled(): Boolean {
+        return storage.getBoolean("pref_higher_contrast_enabled", false)
+    }
+
     /**
      * @return An integer representing the first day of the week. Sunday
      * corresponds to 1, Monday to 2, and so on, until Saturday, which is


### PR DESCRIPTION
This PR should resolve the following:

#413 
#649 
#719 
#777
#843 

A new setting was added for a user to **opt-in** to using medium contrast for the checkmarks, X, and ? symbols for tasks. Other than the additional setting no other visual changes are made to the default state of the app. This should help with the concern of major change noted in #777 since again it is entirely **opt-in** for users who want or need the setting, existing users would see no change. No other UI elements seemed affected by this change.

I did also share the example screenshots with independent parties who did not feel the updated contrast clashed with the existing UI. To me the updated color also seems to more closely match the labels for the days as well, though due to them being larger they are sharper.

As much as I could I tried to keep variable and preference names similar to those already defined. I also ensured the text did not overflow in the settings menu, and placed it in the `Interface` section which seemed appropriate. I am allowing edits from the maintainers on this PR to adjust this text as they see fit for better clarity, or to fit their preferred style/wording.

Two issues I ran into:

1. My platform does not support running the tests from the bash script. Can I please get assistance with ensuring these run on this PR?
2. I do not speak languages other than English, so was not able to add translated strings. That being said I didn't see translation for the ? setting in those files either, so not sure this will be a big deal.

Screenshot of new setting:

![screenshot_2021-03-13_12-03-28](https://user-images.githubusercontent.com/70103789/111042908-4018c480-8405-11eb-8cb3-4ac850583182.png)

Original low contrast color:

![screenshot_2021-03-13_12-00-39](https://user-images.githubusercontent.com/70103789/111042967-7fdfac00-8405-11eb-8e42-749f7c05c939.png)
![screenshot_2021-03-13_12-01-18](https://user-images.githubusercontent.com/70103789/111042970-853cf680-8405-11eb-922c-89ddc33853bf.png)

With higher contrast setting enabled:

![screenshot_2021-03-13_12-01-46](https://user-images.githubusercontent.com/70103789/111042978-9128b880-8405-11eb-95a1-df42266af0fe.png)
![screenshot_2021-03-13_12-01-36](https://user-images.githubusercontent.com/70103789/111042981-9554d600-8405-11eb-8d5b-110640ba6ece.png)


