### PR TITLE
Fix app crash on habit deletion when sorted not manually.

### DIFF
--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/sqlite/SQLiteHabitList.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/sqlite/SQLiteHabitList.kt
@@ -131,9 +131,6 @@ class SQLiteHabitList @Inject constructor(private val modelFactory: ModelFactory
     @Synchronized
     override fun remove(h: Habit) {
         loadRecords()
-        if (Order.BY_POSITION.equals(list.primaryOrder)) {
-            reorder(h, list.getByPosition(size() - 1))
-        }
         list.remove(h)
         val record = repository.find(
             h.id!!
@@ -142,6 +139,7 @@ class SQLiteHabitList @Inject constructor(private val modelFactory: ModelFactory
             h.originalEntries.clear()
             repository.remove(record)
         }
+        rebuildOrder()
         observable.notifyListeners()
     }
 

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/sqlite/SQLiteHabitList.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/sqlite/SQLiteHabitList.kt
@@ -131,7 +131,9 @@ class SQLiteHabitList @Inject constructor(private val modelFactory: ModelFactory
     @Synchronized
     override fun remove(h: Habit) {
         loadRecords()
-        reorder(h, list.getByPosition(size() - 1))
+        if (Order.BY_POSITION.equals(list.primaryOrder)) {
+            reorder(h, list.getByPosition(size() - 1))
+        }
         list.remove(h)
         val record = repository.find(
             h.id!!

--- a/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/models/sqlite/SQLiteHabitListTest.kt
+++ b/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/models/sqlite/SQLiteHabitListTest.kt
@@ -157,6 +157,14 @@ class SQLiteHabitListTest : BaseUnitTest() {
         val h = habitList.getById(2)
         habitList.remove(h!!)
         assertThat(habitList.indexOf(h), equalTo(-1))
+
+        habitList.add(h)
+        val primaryOrder = habitList.primaryOrder
+        habitList.primaryOrder = HabitList.Order.BY_NAME_DESC
+        habitList.remove(h)
+        assertThat(habitList.indexOf(h), equalTo(-1))
+        habitList.primaryOrder = primaryOrder
+
         var rec = repository.find(2L)
         assertNull(rec)
         rec = repository.find(3L)!!

--- a/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/models/sqlite/SQLiteHabitListTest.kt
+++ b/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/models/sqlite/SQLiteHabitListTest.kt
@@ -158,12 +158,18 @@ class SQLiteHabitListTest : BaseUnitTest() {
         habitList.remove(h!!)
         assertThat(habitList.indexOf(h), equalTo(-1))
 
-        habitList.add(h)
-        val primaryOrder = habitList.primaryOrder
+        var rec = repository.find(2L)
+        assertNull(rec)
+        rec = repository.find(3L)!!
+        assertThat(rec.position, equalTo(1))
+    }
+
+    @Test
+    fun testRemove_orderByName() {
         habitList.primaryOrder = HabitList.Order.BY_NAME_DESC
-        habitList.remove(h)
+        val h = habitList.getById(2)
+        habitList.remove(h!!)
         assertThat(habitList.indexOf(h), equalTo(-1))
-        habitList.primaryOrder = primaryOrder
 
         var rec = repository.find(2L)
         assertNull(rec)


### PR DESCRIPTION
As mentioned in [descussion](https://github.com/iSoron/uhabits/discussions/42#discussioncomment-246040), deletion of habit when sorted not manually (by name, color, etc.) crashes app.
This was fixed by check that the type of order is BY_POSITION (manual) before reordering.
All tests passed.