### PR TITLE
Add missing dependency to github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,9 @@ jobs:
         name: uhabits-android
         path: uhabits-android/build/outputs/
 
+    - name: Install flock
+      run: brew install util-linux
+
     - name: Run Android Tests
       run: ./build.sh android-tests ${{ matrix.api }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,9 @@ jobs:
       with:
         java-version: 1.8
 
+    - name: Install flock
+      run: brew install util-linux
+
     - name: Build APK & Run small tests
       env:
         RELEASE: 1


### PR DESCRIPTION
The logs after the latest changes were mentioning "flock command missing", this change installs it to prevent this.

I haven't looked into why flock is now required to prevent concurrency issues, but if it is we should make sure it's present.