### PR TITLE
"Add note on a specific day" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,4 @@ contribute, even if you are not a software developer.
 [fdroid]: http://f-droid.org/app/org.isoron.uhabits
 [build]: https://github.com/iSoron/uhabits/blob/dev/docs/BUILD.md
 [beta]: https://play.google.com/apps/testing/org.isoron.uhabits
+ 


### PR DESCRIPTION
Hello everyone, I want to solve this issue #194 and I have made the mockup. I use Figma and you can try it by clicking [here](https://www.figma.com/proto/GuIxtK7gGpn8nTERW7ESLu/loop-habit-tracker-reason-feature?node-id=12%3A1116&scaling=min-zoom&page-id=0%3A1) to see the prototype and [here](https://www.figma.com/file/GuIxtK7gGpn8nTERW7ESLu/loop-habit-tracker-reason-feature?node-id=0%3A1) to see the canvas.

Here is the explanation for my note feature. There are two parts: on the landing page and on the calendar.

Landing page flow

1. Double-tap the cross or check mark to display the input form
2. Write the note
3. Save

Calendar flow

1. Click edit
2. Press-and-hold the date to display the input form
3. Write the note
4. Save

The feedback for this feature is a small dot on the date on calendar.

@iSoron :

> Regarding the UI, how do you propose we display the notes, after entering them?

My solution is to create an input form that expandable to a certain size and the input form can be read and written at the same time. To see the input form, users have to open the calendar section and click on the date that has a note in it. Here is the illustration.

![alt text](https://i.ibb.co/YkxCFx3/Android-6.png)
![alt text](https://i.ibb.co/dBw0jkr/Android-7.png)
![alt text](https://i.ibb.co/XsygQd8/Android-8.png)

So here is my idea and please tell me what you think :)