### PR TITLE
Reduce checkmark widget minimum size for fine-grained home screen grids

### DIFF
--- a/uhabits-android/src/main/res/xml/widget_checkmark_info.xml
+++ b/uhabits-android/src/main/res/xml/widget_checkmark_info.xml
@@ -19,8 +19,8 @@
   -->
 
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-                    android:minHeight="40dp"
-                    android:minWidth="40dp"
+                    android:minHeight="32dp"
+                    android:minWidth="32dp"
                     android:initialLayout="@layout/widget_wrapper"
                     android:previewImage="@drawable/widget_preview_checkmark"
                     android:resizeMode="vertical|horizontal"


### PR DESCRIPTION
On my device (a Pixel 3a configured with a 5x7 homescreen grid, more fine-grained than the default), the 40dp x 40dp minimum dimensions of the checkmark widget end up as 1x2 grid cells, with a *lot* of wasted vertical space. Reducing it to 32dp x 32dp lets me have a 1x1 checkmark widget, which looks fine and works fine while leaving me a lot more screen space to work with.