### PR TITLE
Use notification timestamp when pressing "no"

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/intents/PendingIntentFactory.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/intents/PendingIntentFactory.kt
@@ -63,13 +63,14 @@ class PendingIntentFactory
             FLAG_UPDATE_CURRENT
         )
 
-    fun removeRepetition(habit: Habit): PendingIntent =
+    fun removeRepetition(habit: Habit, timestamp: Timestamp?): PendingIntent =
         getBroadcast(
             context,
             3,
             Intent(context, WidgetReceiver::class.java).apply {
                 action = WidgetReceiver.ACTION_REMOVE_REPETITION
                 data = Uri.parse(habit.uriString)
+                if (timestamp != null) putExtra("timestamp", timestamp.unixTime)
             },
             FLAG_UPDATE_CURRENT
         )

--- a/uhabits-android/src/main/java/org/isoron/uhabits/notifications/AndroidNotificationTray.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/notifications/AndroidNotificationTray.kt
@@ -107,7 +107,7 @@ class AndroidNotificationTray
         val removeRepetitionAction = Action(
             R.drawable.ic_action_cancel,
             context.getString(R.string.no),
-            pendingIntents.removeRepetition(habit)
+            pendingIntents.removeRepetition(habit, timestamp)
         )
 
         val enterAction = Action(


### PR DESCRIPTION
Fixes #969.

The logic was different from the one when pressing "yes", I guess from the days when pressing was a no-op anyway (apart from removing the notif).