### PR TITLE
Make numpad work better in number picker dialog

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/NumberPickerFactory.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/NumberPickerFactory.kt
@@ -33,6 +33,7 @@ import org.isoron.uhabits.R
 import org.isoron.uhabits.core.ui.screens.habits.list.ListHabitsBehavior
 import org.isoron.uhabits.inject.ActivityContext
 import org.isoron.uhabits.utils.InterfaceUtils
+import java.text.DecimalFormatSymbols
 import javax.inject.Inject
 import kotlin.math.roundToLong
 
@@ -51,7 +52,10 @@ class NumberPickerFactory
 
         val picker = view.findViewById<NumberPicker>(R.id.picker)
         val picker2 = view.findViewById<NumberPicker>(R.id.picker2)
-        val tvUnit = view.findViewById<TextView>(R.id.tvUnit)
+
+        view.findViewById<TextView>(R.id.tvUnit).text = unit
+        view.findViewById<TextView>(R.id.tvSeparator).text =
+            DecimalFormatSymbols.getInstance().decimalSeparator.toString()
 
         val intValue = (value * 100).roundToLong().toInt()
 
@@ -61,19 +65,17 @@ class NumberPickerFactory
         picker.wrapSelectorWheel = false
 
         picker2.minValue = 0
-        picker2.maxValue = 19
-        picker2.setFormatter { v -> String.format("%02d", 5 * v) }
-        picker2.value = intValue % 100 / 5
+        picker2.maxValue = 99
+        picker2.setFormatter { v -> String.format("%02d", v) }
+        picker2.value = intValue % 100
         refreshInitialValue(picker2)
-
-        tvUnit.text = unit
 
         val dialog = AlertDialog.Builder(context)
             .setView(view)
             .setTitle(R.string.change_value)
             .setPositiveButton(android.R.string.ok) { _, _ ->
                 picker.clearFocus()
-                val v = picker.value + 0.05 * picker2.value
+                val v = picker.value + 0.01 * picker2.value
                 callback.onNumberPicked(v)
             }
             .setOnDismissListener {

--- a/uhabits-android/src/main/res/layout/number_picker_dialog.xml
+++ b/uhabits-android/src/main/res/layout/number_picker_dialog.xml
@@ -34,14 +34,13 @@
         android:id="@+id/tvSeparator"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="."/>
+        />
 
     <NumberPicker
         android:id="@+id/picker2"
         android:layout_gravity="center"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:descendantFocusability="blocksDescendants"
         />
 
     <TextView


### PR DESCRIPTION
#922

- [x] Make both NumberPickers focusable.
- [X] Make the second NumberPicker have 0.01 increments instead of 0.05.
- [x] Ensure that typing "." in the numpad switches the focus from the first NumberPicker to the second and selects the current number, so that typing "3.14" works as expected.

Currently, entering the decimal part via the numpad has no effect.

I'm trying to listen to key events to switch from one NumberPicker to the other, but I don't see any event for the non-digit (soft) keys. This might be relevant: https://developer.android.com/training/keyboard-input/commands (we cannot rely on such key events).