### PR TITLE
Add option to set default value for habits on unknown days

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/HistoryEditorDialog.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/HistoryEditorDialog.kt
@@ -62,6 +62,7 @@ class HistoryEditorDialog : AppCompatDialogFragment(), CommandRunner.Listener {
             firstWeekday = preferences.firstWeekday,
             paletteColor = habit.color,
             series = emptyList(),
+            defaultSquare = HistoryChart.Square.OFF,
             theme = themeSwitcher.currentTheme,
             today = DateUtils.getTodayWithOffset().toLocalDate(),
             onDateClickedListener = onDateClickedListener ?: OnDateClickedListener { },
@@ -101,6 +102,7 @@ class HistoryEditorDialog : AppCompatDialogFragment(), CommandRunner.Listener {
             theme = LightTheme()
         )
         chart?.series = model.series
+        chart?.defaultSquare = model.defaultSquare
         dataView.postInvalidate()
     }
 

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/CheckmarkButtonView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/CheckmarkButtonView.kt
@@ -65,6 +65,12 @@ class CheckmarkButtonView(
             invalidate()
         }
 
+    var defaultValue: Int = 0
+        set(value) {
+            field = value
+            invalidate()
+        }
+
     var value: Int = 0
         set(value) {
             field = value
@@ -128,7 +134,8 @@ class CheckmarkButtonView(
         }
 
         fun draw(canvas: Canvas) {
-            paint.color = when (value) {
+            val realValue = if (value != UNKNOWN) value else defaultValue
+            paint.color = when (realValue) {
                 YES_MANUAL, YES_AUTO, SKIP -> color
                 NO -> {
                     if (preferences.areQuestionMarksEnabled) mediumContrastColor
@@ -136,15 +143,14 @@ class CheckmarkButtonView(
                 }
                 else -> lowContrastColor
             }
-            val id = when (value) {
+            var id = when (realValue) {
                 SKIP -> R.string.fa_skipped
                 NO -> R.string.fa_times
-                UNKNOWN -> {
-                    if (preferences.areQuestionMarksEnabled) R.string.fa_question
-                    else R.string.fa_times
-                }
                 else -> R.string.fa_check
             }
+            if (value == UNKNOWN && preferences.areQuestionMarksEnabled)
+                id = R.string.fa_question
+
             if (value == YES_AUTO) {
                 paint.strokeWidth = 5f
                 paint.style = Paint.Style.STROKE

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/CheckmarkPanelView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/CheckmarkPanelView.kt
@@ -48,6 +48,12 @@ class CheckmarkPanelView(
             setupButtons()
         }
 
+    var defaultValue = 0
+        set(value) {
+            field = value
+            setupButtons()
+        }
+
     var color = 0
         set(value) {
             field = value
@@ -72,6 +78,7 @@ class CheckmarkPanelView(
                 index + dataOffset < values.size -> values[index + dataOffset]
                 else -> UNKNOWN
             }
+            button.defaultValue = defaultValue
             button.color = color
             button.onToggle = { value -> onToggle(timestamp, value) }
         }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/HabitCardView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/HabitCardView.kt
@@ -228,6 +228,7 @@ class HabitCardView(
         }
         checkmarkPanel.apply {
             color = c
+            defaultValue = h.defaultValue
             visibility = when (h.isNumerical) {
                 true -> View.GONE
                 false -> View.VISIBLE
@@ -235,6 +236,7 @@ class HabitCardView(
         }
         numberPanel.apply {
             color = c
+            defaultValue = h.defaultValue / 1000.0
             units = h.unit
             threshold = h.targetValue
             visibility = when (h.isNumerical) {

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/NumberButtonView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/NumberButtonView.kt
@@ -76,6 +76,12 @@ class NumberButtonView(
             invalidate()
         }
 
+    var defaultValue = 0.0
+        set(value) {
+            field = value
+            invalidate()
+        }
+
     var value = 0.0
         set(value) {
             field = value
@@ -153,9 +159,10 @@ class NumberButtonView(
         }
 
         fun draw(canvas: Canvas) {
+            val realValue = if (value >= 0) value else defaultValue
             val activeColor = when {
-                value <= 0.0 -> lowContrast
-                value < threshold -> mediumContrast
+                realValue == 0.0 -> lowContrast
+                realValue < threshold -> mediumContrast
                 else -> color
             }
 
@@ -175,7 +182,7 @@ class NumberButtonView(
                     textSize = dim(R.dimen.smallerTextSize)
                 }
                 else -> {
-                    label = "0"
+                    label = defaultValue.toShortString()
                     typeface = BOLD_TYPEFACE
                     textSize = dim(R.dimen.smallTextSize)
                 }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/NumberPanelView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/NumberPanelView.kt
@@ -47,6 +47,12 @@ class NumberPanelView(
             setupButtons()
         }
 
+    var defaultValue = 0.0
+        set(value) {
+            field = value
+            setupButtons()
+        }
+
     var threshold = 0.0
         set(value) {
             field = value
@@ -83,6 +89,7 @@ class NumberPanelView(
                 index + dataOffset < values.size -> values[index + dataOffset]
                 else -> 0.0
             }
+            button.defaultValue = defaultValue
             button.color = color
             button.threshold = threshold
             button.units = units

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/views/HistoryCardView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/views/HistoryCardView.kt
@@ -43,6 +43,7 @@ class HistoryCardView(context: Context, attrs: AttributeSet) : LinearLayout(cont
             theme = state.theme,
             dateFormatter = JavaLocalDateFormatter(Locale.getDefault()),
             series = state.series,
+            defaultSquare = state.defaultSquare,
             firstWeekday = state.firstWeekday,
         )
         binding.chart.postInvalidate()

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/HistoryWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/HistoryWidget.kt
@@ -56,7 +56,9 @@ class HistoryWidget(
             theme = WidgetTheme(),
         )
         (widgetView.dataView as AndroidDataView).apply {
-            (this.view as HistoryChart).series = model.series
+            val historyChart = (this.view as HistoryChart)
+            historyChart.series = model.series
+            historyChart.defaultSquare = model.defaultSquare
         }
     }
 
@@ -71,6 +73,7 @@ class HistoryWidget(
                     dateFormatter = JavaLocalDateFormatter(Locale.getDefault()),
                     firstWeekday = prefs.firstWeekday,
                     series = listOf(),
+                    defaultSquare = HistoryChart.Square.OFF
                 )
             }
         ).apply {

--- a/uhabits-android/src/main/res/layout/activity_edit_habit.xml
+++ b/uhabits-android/src/main/res/layout/activity_edit_habit.xml
@@ -151,6 +151,35 @@
                 </LinearLayout>
             </FrameLayout>
 
+            <!-- DefaultValue -->
+            <FrameLayout
+                android:id="@+id/yesNoDefaultOuterBox"
+                style="@style/FormOuterBox">
+                <LinearLayout style="@style/FormInnerBox">
+                    <TextView
+                        style="@style/FormLabel"
+                        android:text="@string/defaultValue" />
+                    <RadioGroup
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal">
+                        <RadioButton android:id="@+id/defaultNo"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:checked="true"
+                            android:text="@string/no"/>
+                        <RadioButton android:id="@+id/defaultYes"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/yes"/>
+                        <RadioButton android:id="@+id/defaultSkip"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/skip"/>
+                    </RadioGroup>
+                </LinearLayout>
+            </FrameLayout>
+
             <!-- Target value, unit and frequency -->
             <FrameLayout
                 android:id="@+id/unitOuterBox"
@@ -180,13 +209,13 @@
                     <LinearLayout style="@style/FormInnerBox">
                         <TextView
                             style="@style/FormLabel"
-                            android:text="@string/target" />
+                            android:text="@string/startAt" />
                         <EditText
                             style="@style/FormInput"
-                            android:id="@+id/targetInput"
+                            android:id="@+id/defaultValueInput"
                             android:maxLines="1"
                             android:inputType="numberDecimal"
-                            android:hint="@string/example_target"/>
+                            android:text="0"/>
                     </LinearLayout>
                 </FrameLayout>
                 <FrameLayout
@@ -196,16 +225,33 @@
                     <LinearLayout style="@style/FormInnerBox">
                         <TextView
                             style="@style/FormLabel"
-                            android:text="@string/frequency" />
-                        <TextView
-                            style="@style/FormDropdown"
-                            android:id="@+id/numericalFrequencyPicker"
-                            android:text="@string/every_week"
-                            android:textColor="?attr/contrast100"
-                            />
+                            android:text="@string/target" />
+                        <EditText
+                            style="@style/FormInput"
+                            android:id="@+id/targetInput"
+                            android:maxLines="1"
+                            android:inputType="numberDecimal"
+                            android:hint="@string/example_target"/>
                     </LinearLayout>
                 </FrameLayout>
             </LinearLayout>
+
+            <FrameLayout
+                android:id='@+id/numericalFrequencyOuterBox'
+                style="@style/FormOuterBox">
+
+                <LinearLayout style="@style/FormInnerBox">
+                    <TextView
+                        style="@style/FormLabel"
+                        android:text="@string/frequency" />
+                    <TextView
+                        style="@style/FormDropdown"
+                        android:id="@+id/numericalFrequencyPicker"
+                        android:text="@string/every_week"
+                        android:textColor="?attr/contrast100"
+                        />
+                </LinearLayout>
+            </FrameLayout>
 
             <!-- Reminder -->
             <FrameLayout style="@style/FormOuterBox">
@@ -213,7 +259,6 @@
                     <TextView
                         style="@style/FormLabel"
                         android:text="@string/reminder" />
-
                     <TextView
                         style="@style/FormDropdown"
                         android:id="@+id/reminderTimePicker"

--- a/uhabits-android/src/main/res/layout/activity_edit_habit.xml
+++ b/uhabits-android/src/main/res/layout/activity_edit_habit.xml
@@ -196,6 +196,24 @@
                         android:hint="@string/measurable_units_example"/>
                 </LinearLayout>
             </FrameLayout>
+            
+            <FrameLayout
+                android:id='@+id/numericalFrequencyOuterBox'
+                style="@style/FormOuterBox">
+
+                <LinearLayout style="@style/FormInnerBox">
+                    <TextView
+                        style="@style/FormLabel"
+                        android:text="@string/frequency" />
+                    <TextView
+                        style="@style/FormDropdown"
+                        android:id="@+id/numericalFrequencyPicker"
+                        android:text="@string/every_week"
+                        android:textColor="?attr/contrast100"
+                        />
+                </LinearLayout>
+            </FrameLayout>
+
             <LinearLayout
                 android:id="@+id/targetOuterBox"
                 android:layout_width="match_parent"
@@ -235,23 +253,6 @@
                     </LinearLayout>
                 </FrameLayout>
             </LinearLayout>
-
-            <FrameLayout
-                android:id='@+id/numericalFrequencyOuterBox'
-                style="@style/FormOuterBox">
-
-                <LinearLayout style="@style/FormInnerBox">
-                    <TextView
-                        style="@style/FormLabel"
-                        android:text="@string/frequency" />
-                    <TextView
-                        style="@style/FormDropdown"
-                        android:id="@+id/numericalFrequencyPicker"
-                        android:text="@string/every_week"
-                        android:textColor="?attr/contrast100"
-                        />
-                </LinearLayout>
-            </FrameLayout>
 
             <!-- Reminder -->
             <FrameLayout style="@style/FormOuterBox">

--- a/uhabits-android/src/main/res/values/strings.xml
+++ b/uhabits-android/src/main/res/values/strings.xml
@@ -118,6 +118,7 @@
     <string name="developers">Developers</string>
     <string name="version_n">Version %s</string>
     <string name="frequency">Frequency</string>
+    <string name="defaultValue">Default value</string>
     <string name="checkmark">Checkmark</string>
     <string name="checkmark_stack_widget" formatted="false">Checkmark Stack Widget</string>
     <string name="frequency_stack_widget" formatted="false">Frequency Stack Widget</string>
@@ -186,9 +187,11 @@
     <string name="unit">Unit</string>
     <string name="example_question_boolean">e.g. Did you exercise today?</string>
     <string name="question">Question</string>
+    <string name="startAt">Starts at</string>
     <string name="target">Target</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
+    <string name="skip">Skip</string>
     <string name="customize_notification_summary">Change sound, vibration, light and other notification settings</string>
     <string name="customize_notification">Customize notifications</string>
     <string name="pref_view_privacy">View privacy policy</string>

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/Constants.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/Constants.kt
@@ -20,4 +20,4 @@ package org.isoron.uhabits.core
 
 const val DATABASE_FILENAME = "uhabits.db"
 
-const val DATABASE_VERSION = 24
+const val DATABASE_VERSION = 25

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/Habit.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/Habit.kt
@@ -35,6 +35,7 @@ data class Habit(
     var targetValue: Double = 0.0,
     var type: HabitType = HabitType.YES_NO,
     var unit: String = "",
+    var defaultValue: Int = 0,
     var uuid: String? = null,
     val computedEntries: EntryList,
     val originalEntries: EntryList,
@@ -69,7 +70,7 @@ data class Habit(
     }
 
     fun isFailedToday(): Boolean {
-        val today = DateUtils.getTodayWithOffset()
+        var today = DateUtils.getTodayWithOffset()
         val value = computedEntries.get(today).value
         return if (isNumerical) {
             when (targetType) {
@@ -88,15 +89,17 @@ data class Habit(
             isNumerical = isNumerical,
         )
 
-        val to = DateUtils.getTodayWithOffset().plus(30)
+        val today = DateUtils.getTodayWithOffset()
+        val to = today.plus(30)
         val entries = computedEntries.getKnown()
-        var from = entries.lastOrNull()?.timestamp ?: to
+        var from = entries.lastOrNull()?.timestamp ?: today
         if (from.isNewerThan(to)) from = to
 
         scores.recompute(
             frequency = frequency,
             isNumerical = isNumerical,
             targetValue = targetValue,
+            defaultValue = defaultValue,
             computedEntries = computedEntries,
             from = from,
             to = to,
@@ -123,6 +126,7 @@ data class Habit(
         this.targetValue = other.targetValue
         this.type = other.type
         this.unit = other.unit
+        this.defaultValue = other.defaultValue
         this.uuid = other.uuid
     }
 
@@ -143,6 +147,7 @@ data class Habit(
         if (targetValue != other.targetValue) return false
         if (type != other.type) return false
         if (unit != other.unit) return false
+        if (defaultValue != other.defaultValue) return false
         if (uuid != other.uuid) return false
 
         return true
@@ -162,6 +167,7 @@ data class Habit(
         result = 31 * result + targetValue.hashCode()
         result = 31 * result + type.value
         result = 31 * result + unit.hashCode()
+        result = 31 * result + defaultValue.hashCode()
         result = 31 * result + (uuid?.hashCode() ?: 0)
         return result
     }

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/ScoreList.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/ScoreList.kt
@@ -101,10 +101,9 @@ class ScoreList {
         if (isNumerical) {
             rollingSum = defaultValue.toDouble() * denominator
             previousValue = numericalPercentageComplete(rollingSum)
-            rollingSum -= defaultValue
         } else if (defaultValue == Entry.YES_MANUAL) {
             previousValue = 1.0
-            rollingSum = denominator.toDouble() - 1
+            rollingSum = denominator.toDouble()
         }
 
         for (i in values.indices) {
@@ -113,7 +112,10 @@ class ScoreList {
                 rollingSum += values[offset]
                 if (offset + denominator < values.size) {
                     rollingSum -= values[offset + denominator]
+                } else {
+                    rollingSum -= defaultValue
                 }
+
                 val percentageCompleted = numericalPercentageComplete(rollingSum)
                 previousValue = compute(freq, previousValue, percentageCompleted)
             } else {
@@ -123,6 +125,8 @@ class ScoreList {
                 if (offset + denominator < values.size) {
                     if (values[offset + denominator] == Entry.YES_MANUAL) {
                         rollingSum -= 1.0
+                    } else {
+                        rollingSum -= defaultValue
                     }
                 }
                 if (values[offset] != Entry.SKIP) {

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/sqlite/records/HabitRecord.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/sqlite/records/HabitRecord.kt
@@ -83,6 +83,9 @@ class HabitRecord {
     var unit: String? = null
 
     @field:Column
+    var defaultValue: Int? = null
+
+    @field:Column
     var id: Long? = null
 
     @field:Column
@@ -99,6 +102,7 @@ class HabitRecord {
         targetType = model.targetType.value
         targetValue = model.targetValue
         unit = model.unit
+        defaultValue = model.defaultValue
         position = model.position
         question = model.question
         uuid = model.uuid
@@ -128,6 +132,7 @@ class HabitRecord {
         habit.targetType = NumericalHabitType.fromInt(targetType!!)
         habit.targetValue = targetValue!!
         habit.unit = unit!!
+        habit.defaultValue = defaultValue!!
         habit.position = position!!
         habit.uuid = uuid
         if (reminderHour != null && reminderMin != null) {

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsBehavior.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsBehavior.kt
@@ -20,6 +20,7 @@ package org.isoron.uhabits.core.ui.screens.habits.list
 
 import org.isoron.uhabits.core.commands.CommandRunner
 import org.isoron.uhabits.core.commands.CreateRepetitionCommand
+import org.isoron.uhabits.core.models.Entry
 import org.isoron.uhabits.core.models.Habit
 import org.isoron.uhabits.core.models.HabitList
 import org.isoron.uhabits.core.models.Timestamp
@@ -48,9 +49,10 @@ open class ListHabitsBehavior @Inject constructor(
 
     fun onEdit(habit: Habit, timestamp: Timestamp?) {
         val entries = habit.computedEntries
-        val oldValue = entries.get(timestamp!!).value.toDouble()
+        var oldValue = entries.get(timestamp!!).value
+        oldValue = if (oldValue != Entry.UNKNOWN) oldValue else habit.defaultValue
         screen.showNumberPicker(
-            oldValue / 1000,
+            oldValue.toDouble() / 1000,
             habit.unit
         ) { newValue: Double ->
             val value = (newValue * 1000).roundToInt()

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/views/HistoryChart.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/views/HistoryChart.kt
@@ -41,6 +41,7 @@ class HistoryChart(
     var firstWeekday: DayOfWeek,
     var paletteColor: PaletteColor,
     var series: List<Square>,
+    var defaultSquare: Square,
     var theme: Theme,
     var today: LocalDate,
     var onDateClickedListener: OnDateClickedListener = OnDateClickedListener { },
@@ -189,7 +190,7 @@ class HistoryChart(
         offset: Int,
     ) {
 
-        val value = if (offset >= series.size) Square.OFF else series[offset]
+        val value = if (offset >= series.size) defaultSquare else series[offset]
         val squareColor: Color
         val color = theme.color(paletteColor.paletteIndex)
         squareColor = when (value) {

--- a/uhabits-core/src/jvmMain/resources/migrations/25.sql
+++ b/uhabits-core/src/jvmMain/resources/migrations/25.sql
@@ -1,0 +1,1 @@
+alter table Habits add column defaultValue integer not null default 0;

--- a/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/ui/views/HistoryChartTest.kt
+++ b/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/ui/views/HistoryChartTest.kt
@@ -49,6 +49,7 @@ class HistoryChartTest {
         dateFormatter = JavaLocalDateFormatter(Locale.US),
         firstWeekday = SUNDAY,
         onDateClickedListener = dateClickedListener,
+        defaultSquare = OFF,
         series = listOf(
             2, // today
             2, 1, 2, 1, 2, 1, 2,


### PR DESCRIPTION
Implements: https://github.com/iSoron/uhabits/discussions/125
![image](https://user-images.githubusercontent.com/3768676/133898312-bc20b9e6-4caa-44d3-92d6-a6e785314d0d.png)
![image](https://user-images.githubusercontent.com/3768676/133899754-4e1fb690-7fff-4ed1-9839-b168f55681eb.png)

This change propagates to a lot of places so list of things:
**Implemented**
1) History card can have a default square depending on the default value
2) Scores can now start from values above 0.
3) Main screen can start with completed habits, but they are not filtered unless you specifically enter the value.

**Things to do left**
- [ ] Happy to get guidance of the order of numerical EditHabit dialog and the titles for the new value to make it prettier
- [ ] Score is mostly consistent, but score chart starts from the first repetition. Do we want to change that?
- [ ] Streaks are not calculated for default value YES. Are we okay with them being calculated from the first "actual" occurence?
- [ ] Frequency/History/Total in the habit page is inconsistent with these default values too
- [x] ~I expect some tests to crash, but I prefer some guidance on the above before I continue~
- [ ] We probably need to add a lot of new tests to cover this functionality as well

@iSoron Waiting on some guidance for all of this before I continue cause it's a lot and don't want to spend more effort if you don't like where this is going.