### PR TITLE
Place MidnightTimer under test

### DIFF
--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/utils/DateUtils.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/utils/DateUtils.kt
@@ -37,9 +37,14 @@ abstract class DateUtils {
         private var startDayMinuteOffset: Int = 0
 
         /**
+         * Number of milliseconds in one second.
+         */
+        const val SECOND_LENGTH: Long = 1000
+
+        /**
          * Number of milliseconds in one minute.
          */
-        const val MINUTE_LENGTH: Long = 60 * 1000
+        const val MINUTE_LENGTH: Long = 60 * SECOND_LENGTH
 
         /**
          * Number of milliseconds in one hour.

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/utils/MidnightTimer.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/utils/MidnightTimer.kt
@@ -39,7 +39,7 @@ open class MidnightTimer @Inject constructor() {
 
     @Synchronized fun onPause(): MutableList<Runnable>? = executor.shutdownNow()
 
-    @Synchronized fun onResume(delayOffsetInMillis: Long = DateUtils.MINUTE_LENGTH, testExecutor: ScheduledExecutorService? = null) {
+    @Synchronized fun onResume(delayOffsetInMillis: Long = DateUtils.SECOND_LENGTH, testExecutor: ScheduledExecutorService? = null) {
         executor = testExecutor ?: Executors.newSingleThreadScheduledExecutor()
         executor.scheduleAtFixedRate(
             { notifyListeners() },

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/utils/MidnightTimer.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/utils/MidnightTimer.kt
@@ -33,13 +33,19 @@ open class MidnightTimer @Inject constructor() {
     private val listeners: MutableList<MidnightListener> = LinkedList()
     private lateinit var executor: ScheduledExecutorService
 
-    @Synchronized fun addListener(listener: MidnightListener) {
+    @Synchronized
+    fun addListener(listener: MidnightListener) {
         this.listeners.add(listener)
     }
 
-    @Synchronized fun onPause(): MutableList<Runnable>? = executor.shutdownNow()
+    @Synchronized
+    fun onPause(): MutableList<Runnable>? = executor.shutdownNow()
 
-    @Synchronized fun onResume(delayOffsetInMillis: Long = DateUtils.SECOND_LENGTH, testExecutor: ScheduledExecutorService? = null) {
+    @Synchronized
+    fun onResume(
+        delayOffsetInMillis: Long = DateUtils.SECOND_LENGTH,
+        testExecutor: ScheduledExecutorService? = null
+    ) {
         executor = testExecutor ?: Executors.newSingleThreadScheduledExecutor()
         executor.scheduleAtFixedRate(
             { notifyListeners() },
@@ -49,9 +55,11 @@ open class MidnightTimer @Inject constructor() {
         )
     }
 
-    @Synchronized fun removeListener(listener: MidnightListener) = this.listeners.remove(listener)
+    @Synchronized
+    fun removeListener(listener: MidnightListener) = this.listeners.remove(listener)
 
-    @Synchronized private fun notifyListeners() {
+    @Synchronized
+    private fun notifyListeners() {
         for (l in listeners) {
             l.atMidnight()
         }

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/utils/MidnightTimer.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/utils/MidnightTimer.kt
@@ -57,7 +57,7 @@ open class MidnightTimer @Inject constructor() {
         }
     }
 
-    interface MidnightListener {
+    fun interface MidnightListener {
         fun atMidnight()
     }
 }

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/utils/MidnightTimer.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/utils/MidnightTimer.kt
@@ -39,11 +39,11 @@ open class MidnightTimer @Inject constructor() {
 
     @Synchronized fun onPause(): MutableList<Runnable>? = executor.shutdownNow()
 
-    @Synchronized fun onResume() {
-        executor = Executors.newSingleThreadScheduledExecutor()
+    @Synchronized fun onResume(delayOffsetInMillis: Long = DateUtils.MINUTE_LENGTH, testExecutor: ScheduledExecutorService? = null) {
+        executor = testExecutor ?: Executors.newSingleThreadScheduledExecutor()
         executor.scheduleAtFixedRate(
             { notifyListeners() },
-            DateUtils.millisecondsUntilTomorrowWithOffset() + 1000,
+            DateUtils.millisecondsUntilTomorrowWithOffset() + delayOffsetInMillis,
             DateUtils.DAY_LENGTH,
             TimeUnit.MILLISECONDS
         )

--- a/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/BaseUnitTest.kt
+++ b/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/BaseUnitTest.kt
@@ -95,15 +95,13 @@ open class BaseUnitTest {
     }
 
     fun unixTime(year: Int, month: Int, day: Int): Long {
-        val cal = getStartOfTodayCalendar()
-        cal.set(year, month, day, 0, 0, 0)
-        return cal.timeInMillis
+        return unixTime(year, month, day, 0, 0)
     }
 
-    open fun unixTime(year: Int, month: Int, day: Int, hour: Int, minute: Int): Long {
+    open fun unixTime(year: Int, month: Int, day: Int, hour: Int, minute: Int, milliseconds: Long = 0): Long {
         val cal = getStartOfTodayCalendar()
         cal.set(year, month, day, hour, minute)
-        return cal.timeInMillis
+        return cal.timeInMillis + milliseconds
     }
 
     fun timestamp(year: Int, month: Int, day: Int): Timestamp {

--- a/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/reminders/ReminderSchedulerTest.kt
+++ b/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/reminders/ReminderSchedulerTest.kt
@@ -138,7 +138,7 @@ class ReminderSchedulerTest : BaseUnitTest() {
         reminderScheduler.schedule(habit)
     }
 
-    override fun unixTime(year: Int, month: Int, day: Int, hour: Int, minute: Int): Long {
+    override fun unixTime(year: Int, month: Int, day: Int, hour: Int, minute: Int, milliseconds: Long): Long {
         val cal: Calendar = getStartOfTodayCalendar()
         cal[year, month, day, hour] = minute
         return cal.timeInMillis

--- a/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/utils/MidnightTimerTest.kt
+++ b/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/utils/MidnightTimerTest.kt
@@ -1,0 +1,45 @@
+package org.isoron.uhabits.core.utils
+
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.isoron.uhabits.core.BaseUnitTest
+import org.junit.Test
+import java.util.Calendar
+import java.util.TimeZone
+import java.util.concurrent.Executors
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+import kotlin.test.assertEquals
+
+class MidnightTimerTest : BaseUnitTest() {
+
+    @Test
+    fun testMidnightTimer_notifyListener_atMidnight() = runBlocking {
+        // Given
+        val executor = Executors.newSingleThreadScheduledExecutor()
+        val dispatcher = executor.asCoroutineDispatcher()
+
+        withContext(dispatcher) {
+            DateUtils.setFixedTimeZone(TimeZone.getTimeZone("GMT"))
+            DateUtils.setFixedLocalTime(unixTime(2017, Calendar.JANUARY, 1, 23, 59, DateUtils.MINUTE_LENGTH - 1))
+
+            val suspendedListener = suspendCoroutine<Boolean> { continuation ->
+                val listener = object : MidnightTimer.MidnightListener {
+                    override fun atMidnight() {
+                        continuation.resume(true)
+                    }
+                }
+
+                MidnightTimer().apply {
+                    addListener(listener)
+                    // When
+                    onResume(1, executor)
+                }
+            }
+
+            // Then
+            assertEquals(true, suspendedListener)
+        }
+    }
+}

--- a/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/utils/MidnightTimerTest.kt
+++ b/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/utils/MidnightTimerTest.kt
@@ -22,7 +22,16 @@ class MidnightTimerTest : BaseUnitTest() {
 
         withContext(dispatcher) {
             DateUtils.setFixedTimeZone(TimeZone.getTimeZone("GMT"))
-            DateUtils.setFixedLocalTime(unixTime(2017, Calendar.JANUARY, 1, 23, 59, DateUtils.MINUTE_LENGTH - 1))
+            DateUtils.setFixedLocalTime(
+                unixTime(
+                    2017,
+                    Calendar.JANUARY,
+                    1,
+                    23,
+                    59,
+                    DateUtils.MINUTE_LENGTH - 1
+                )
+            )
 
             val suspendedListener = suspendCoroutine<Boolean> { continuation ->
                 MidnightTimer().apply {

--- a/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/utils/MidnightTimerTest.kt
+++ b/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/utils/MidnightTimerTest.kt
@@ -25,14 +25,8 @@ class MidnightTimerTest : BaseUnitTest() {
             DateUtils.setFixedLocalTime(unixTime(2017, Calendar.JANUARY, 1, 23, 59, DateUtils.MINUTE_LENGTH - 1))
 
             val suspendedListener = suspendCoroutine<Boolean> { continuation ->
-                val listener = object : MidnightTimer.MidnightListener {
-                    override fun atMidnight() {
-                        continuation.resume(true)
-                    }
-                }
-
                 MidnightTimer().apply {
-                    addListener(listener)
+                    addListener { continuation.resume(true) }
                     // When
                     onResume(1, executor)
                 }


### PR DESCRIPTION
MidnightTimer will need to move from executor to coroutine in order to complete Issue #1075
Prepares MidnightTimer to be testable with coroutine.
Requires removal of JVM dependencies from DateUtils before we can convert MidnightTimer though.