### PR TITLE
Add border to create habit buttons

### DIFF
--- a/uhabits-android/src/main/res/drawable/round_ripple.xml
+++ b/uhabits-android/src/main/res/drawable/round_ripple.xml
@@ -23,6 +23,7 @@
     android:color="?colorAccent">
     <item android:gravity="center">
         <shape android:shape="rectangle">
+            <stroke android:width="2dp" android:color="?android:textColor"/>
             <solid android:color="?cardBgColor"/>
             <corners android:radius="5dp" />
         </shape>


### PR DESCRIPTION
Based on the discussion here https://github.com/iSoron/uhabits/discussions/1105, @MechtEngineer made a good point that on a pure black theme the buttons in create a new habit don't really look like buttons because their background and the actual background are both pure black.
I'm adding a border of the button with the text color to highlight the boundary more clearly. This is what it looks like on different theme options:
![image](https://user-images.githubusercontent.com/3768676/134355590-d9037da6-0a6b-4388-97a8-52315a7e90a1.png)
![image](https://user-images.githubusercontent.com/3768676/134355647-3c8e6964-cc62-4450-99ba-180cf614fb3a.png)
![image](https://user-images.githubusercontent.com/3768676/134355699-8a0c43c9-bf67-446e-b284-106b9ec93186.png)
