### PR TITLE
Implement skipPressed for Intro, update to latest version of AppIntro

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,5 +20,6 @@ allprojects {
         maven(url = "https://oss.sonatype.org/content/repositories/snapshots/")
         maven(url = "https://kotlin.bintray.com/ktor")
         maven(url = "https://kotlin.bintray.com/kotlin-js-wrappers")
+        maven(url = "https://jitpack.io")
     }
 }

--- a/uhabits-android/build.gradle.kts
+++ b/uhabits-android/build.gradle.kts
@@ -105,7 +105,7 @@ dependencies {
     androidTestImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
     compileOnly("javax.annotation:jsr250-api:1.0")
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
-    implementation("com.github.paolorotolo:appintro:4.1.0")
+    implementation("com.github.AppIntro:AppIntro:6.1.0")
     implementation("com.google.code.findbugs:jsr305:3.0.2")
     implementation("com.google.dagger:dagger:$daggerVersion")
     implementation("com.google.guava:guava:30.1.1-android")

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/intro/IntroActivity.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/intro/IntroActivity.kt
@@ -21,8 +21,9 @@ package org.isoron.uhabits.activities.intro
 
 import android.graphics.Color
 import android.os.Bundle
-import com.github.paolorotolo.appintro.AppIntro2
-import com.github.paolorotolo.appintro.AppIntroFragment
+import androidx.fragment.app.Fragment
+import com.github.appintro.AppIntro2
+import com.github.appintro.AppIntroFragment
 import org.isoron.uhabits.R
 
 /**
@@ -30,7 +31,9 @@ import org.isoron.uhabits.R
  * launched for the first time.
  */
 class IntroActivity : AppIntro2() {
-    override fun init(savedInstanceState: Bundle?) {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
         showStatusBar(false)
 
         addSlide(
@@ -61,9 +64,8 @@ class IntroActivity : AppIntro2() {
         )
     }
 
-    override fun onNextPressed() {}
-
-    override fun onDonePressed() {
+    override fun onDonePressed(currentFragment: Fragment?) {
+        super.onDonePressed(currentFragment)
         finish()
     }
 

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/intro/IntroActivity.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/intro/IntroActivity.kt
@@ -67,5 +67,8 @@ class IntroActivity : AppIntro2() {
         finish()
     }
 
-    override fun onSlideChanged() {}
+    override fun onSkipPressed(currentFragment: Fragment?) {
+        super.onSkipPressed(currentFragment)
+        finish()
+    }
 }


### PR DESCRIPTION
For the app intro, pressing the Skip button would do nothing. Added support to finish the activity.
Also updated to the latest version of AppIntro using this migration doc: https://github.com/AppIntro/AppIntro/blob/master/docs/migrating-from-5.0.md