### PR TITLE
Fix "hide completed" for numerical habits

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsActivity.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsActivity.kt
@@ -53,6 +53,7 @@ class ListHabitsActivity : AppCompatActivity(), Preferences.Listener {
 
     override fun onQuestionMarksChanged() {
         invalidateOptionsMenu()
+        menu.behavior.onPreferencesChanged()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsMenu.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsMenu.kt
@@ -39,7 +39,7 @@ class ListHabitsMenu @Inject constructor(
     @ActivityContext context: Context,
     private val preferences: Preferences,
     private val themeSwitcher: ThemeSwitcher,
-    private val behavior: ListHabitsMenuBehavior
+    val behavior: ListHabitsMenuBehavior
 ) {
     val activity = (context as AppCompatActivity)
 

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/Habit.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/Habit.kt
@@ -68,17 +68,10 @@ data class Habit(
         }
     }
 
-    fun isFailedToday(): Boolean {
+    fun isEnteredToday(): Boolean {
         val today = DateUtils.getTodayWithOffset()
         val value = computedEntries.get(today).value
-        return if (isNumerical) {
-            when (targetType) {
-                NumericalHabitType.AT_LEAST -> value / 1000.0 < targetValue
-                NumericalHabitType.AT_MOST -> value / 1000.0 > targetValue
-            }
-        } else {
-            value == Entry.NO
-        }
+        return value != Entry.UNKNOWN
     }
 
     fun recompute() {

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/HabitMatcher.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/HabitMatcher.kt
@@ -22,11 +22,13 @@ data class HabitMatcher(
     val isArchivedAllowed: Boolean = false,
     val isReminderRequired: Boolean = false,
     val isCompletedAllowed: Boolean = true,
+    val isEnteredAllowed: Boolean = true,
 ) {
     fun matches(habit: Habit): Boolean {
         if (!isArchivedAllowed && habit.isArchived) return false
         if (isReminderRequired && !habit.hasReminder()) return false
-        if (!isCompletedAllowed && (habit.isCompletedToday() || habit.isFailedToday())) return false
+        if (!isCompletedAllowed && habit.isCompletedToday()) return false
+        if (!isEnteredAllowed && habit.isEnteredToday()) return false
         return true
     }
 

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsMenuBehavior.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsMenuBehavior.kt
@@ -32,6 +32,7 @@ class ListHabitsMenuBehavior @Inject constructor(
 ) {
     private var showCompleted: Boolean
     private var showArchived: Boolean
+
     fun onCreateHabit() {
         screen.showSelectHabitTypeDialog()
     }
@@ -96,13 +97,26 @@ class ListHabitsMenuBehavior @Inject constructor(
         screen.applyTheme()
     }
 
+    fun onPreferencesChanged() {
+        updateAdapterFilter()
+    }
+
     private fun updateAdapterFilter() {
-        adapter.setFilter(
-            HabitMatcher(
-                isArchivedAllowed = showArchived,
-                isCompletedAllowed = showCompleted,
+        if (preferences.areQuestionMarksEnabled) {
+            adapter.setFilter(
+                HabitMatcher(
+                    isArchivedAllowed = showArchived,
+                    isEnteredAllowed = showCompleted,
+                )
             )
-        )
+        } else {
+            adapter.setFilter(
+                HabitMatcher(
+                    isArchivedAllowed = showArchived,
+                    isCompletedAllowed = showCompleted,
+                )
+            )
+        }
         adapter.refresh()
     }
 

--- a/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/models/HabitTest.kt
+++ b/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/models/HabitTest.kt
@@ -82,12 +82,12 @@ class HabitTest : BaseUnitTest() {
 
     @Test
     @Throws(Exception::class)
-    fun test_isFailed() {
+    fun test_isEntered() {
         val h = modelFactory.buildHabit()
-        assertFalse(h.isFailedToday())
+        assertFalse(h.isEnteredToday())
         h.originalEntries.add(Entry(getToday(), Entry.NO))
         h.recompute()
-        assertTrue(h.isFailedToday())
+        assertTrue(h.isEnteredToday())
     }
 
     @Test
@@ -117,35 +117,6 @@ class HabitTest : BaseUnitTest() {
         h.originalEntries.add(Entry(getToday(), 50000))
         h.recompute()
         assertTrue(h.isCompletedToday())
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun test_isFailedNumerical() {
-        val h = modelFactory.buildHabit()
-        h.type = HabitType.NUMERICAL
-        h.targetType = NumericalHabitType.AT_LEAST
-        h.targetValue = 100.0
-        assertTrue(h.isFailedToday())
-        h.originalEntries.add(Entry(getToday(), 200000))
-        h.recompute()
-        assertFalse(h.isFailedToday())
-        h.originalEntries.add(Entry(getToday(), 100000))
-        h.recompute()
-        assertFalse(h.isFailedToday())
-        h.originalEntries.add(Entry(getToday(), 50000))
-        h.recompute()
-        assertTrue(h.isFailedToday())
-        h.targetType = NumericalHabitType.AT_MOST
-        h.originalEntries.add(Entry(getToday(), 200000))
-        h.recompute()
-        assertTrue(h.isFailedToday())
-        h.originalEntries.add(Entry(getToday(), 100000))
-        h.recompute()
-        assertFalse(h.isFailedToday())
-        h.originalEntries.add(Entry(getToday(), 50000))
-        h.recompute()
-        assertFalse(h.isFailedToday())
     }
 
     @Test


### PR DESCRIPTION
Bug #1179 was introduced in 7fe3ce970c42015305cb007b826d9e4d117cfdc5. It appears that the main problem was the lack of clarity in the meaning of `HabitMatcher.isCompletedAllowed`. This PR fixes the issue by introducing the following changes:

1. Replace `Habit.isFailedToday` by `Habit.isEnteredToday`
2. Add `isEnteredAllowed` in `HabitMatcher` and simplify the check
3. In `ListHabitsMenuBehavior`, set different filters according to `preferences.areQuestionMarksEnabled`

@hiqua As you wrote the original commit and identified the issue, would you like to review this?