### PR TITLE
Start the cumulative numerical habit implementation

### DIFF
--- a/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/models/EntryListTest.kt
+++ b/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/models/EntryListTest.kt
@@ -96,7 +96,7 @@ class EntryListTest {
     }
 
     @Test
-    fun testComputeNumerical() {
+    fun testComputeNumericalDaily() {
         val today = DateUtils.getToday()
 
         val original = EntryList()
@@ -110,6 +110,26 @@ class EntryListTest {
         val expected = listOf(
             Entry(today.minus(4), 100),
             Entry(today.minus(9), 200),
+            Entry(today.minus(10), 300),
+        )
+        assertEquals(expected, computed.getKnown())
+    }
+
+    @Test
+    fun testComputeNumericalWeekly() {
+        val today = DateUtils.getToday()
+
+        val original = EntryList()
+        original.add(Entry(today.minus(4), 100))
+        original.add(Entry(today.minus(9), 200))
+        original.add(Entry(today.minus(10), 300))
+
+        val computed = EntryList()
+        computed.recomputeFrom(original, Frequency.WEEKLY, isNumerical = true)
+
+        val expected = listOf(
+            Entry(today.minus(4), 600),
+            Entry(today.minus(9), 500),
             Entry(today.minus(10), 300),
         )
         assertEquals(expected, computed.getKnown())


### PR DESCRIPTION
This implementation doesn't work, because we then only show the sum of the past few days instead of today's value.

See the TODO in the code, but I think that we need another `value` field in the Entry.

I think at this point it would make sense to more cleanly separate between numerical and yes/no habits, e.g. have a proper `NumericalEntry` class. This will probably require a lot of changes in the data model though, so I was curious about your opinion about this.