### PR TITLE
Fixed edit history calendar bug

### DIFF
--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/views/HistoryChart.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/views/HistoryChart.kt
@@ -75,7 +75,7 @@ class HistoryChart(
         val col = ((x - padding) / squareSize).toInt()
         val row = ((y - padding) / squareSize).toInt()
         val offset = col * 7 + (row - 1)
-        if (row == 0 || col == nColumns) return
+        if (x - padding < 0 || row == 0 || row > 7 || col == nColumns) return
         val clickedDate = topLeftDate.plus(offset)
         if (clickedDate.isNewerThan(today)) return
         onDateClickedListener.onDateClicked(clickedDate)


### PR DESCRIPTION
While working on this I noticed that the same bug is happening if we click to the left of the first column (easier to reproduce if you increase dialog padding in HistoryEditorDialog line 68). It doesn't look as bad as the bug that was described in #1282, but I fixed it anyway. Resolves #1282.