### PR TITLE
Add archive actions if there are archived habits

### DIFF
--- a/uhabits-ios/Application/Frontend/MainScreenController.swift
+++ b/uhabits-ios/Application/Frontend/MainScreenController.swift
@@ -190,18 +190,20 @@ class MainScreenController: UITableViewController, MainScreenDataSourceListener 
     @objc func onMoreActionsClicked() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
-        if preferences.showArchived {
-            alert.addAction(UIAlertAction(title: strings.hide_archived, style: .default) {
-                (action: UIAlertAction) -> Void in
-                self.preferences.showArchived = false
-                self.dataSource.requestData()
-            })
-        } else {
-            alert.addAction(UIAlertAction(title: strings.show_archived, style: .default) {
-                (action: UIAlertAction) -> Void in
-                self.preferences.showArchived = true
-                self.dataSource.requestData()
-            })
+        if isThereAnyArchivedHabit() {
+            if preferences.showArchived {
+                alert.addAction(UIAlertAction(title: strings.hide_archived, style: .default) {
+                    (action: UIAlertAction) -> Void in
+                    self.preferences.showArchived = false
+                    self.dataSource.requestData()
+                })
+            } else {
+                alert.addAction(UIAlertAction(title: strings.show_archived, style: .default) {
+                    (action: UIAlertAction) -> Void in
+                    self.preferences.showArchived = true
+                    self.dataSource.requestData()
+                })
+            }
         }
 
         if preferences.showCompleted {
@@ -261,5 +263,9 @@ class MainScreenController: UITableViewController, MainScreenDataSourceListener 
     func reload() {
         let sections = NSIndexSet(indexesIn: NSMakeRange(0, self.tableView.numberOfSections))
         tableView.reloadSections(sections as IndexSet, with: .automatic)
+    }
+    
+    func isThereAnyArchivedHabit() -> Bool {
+        return data!.habits.filter({ $0.isArchived }).count > 0
     }
 }


### PR DESCRIPTION
Adds implementation for the subtask 'Only display "show archived" if there are archived habits' of https://github.com/iSoron/uhabits/issues/487. If there is not any archived habit, 'Show archived' and 'Hide archived' actions will not be displayed.