### PR TITLE
Widget fixes

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsActivity.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsActivity.kt
@@ -85,7 +85,6 @@ class ListHabitsActivity : AppCompatActivity(), Preferences.Listener {
         Thread.setDefaultUncaughtExceptionHandler(BaseExceptionHandler(this))
         component.listHabitsBehavior.onStartup()
         setContentView(rootView)
-        parseIntents()
     }
 
     override fun onPause() {
@@ -110,6 +109,7 @@ class ListHabitsActivity : AppCompatActivity(), Preferences.Listener {
         if (prefs.theme == THEME_DARK && prefs.isPureBlackEnabled != pureBlack) {
             restartWithFade(ListHabitsActivity::class.java)
         }
+        parseIntents()
         super.onResume()
     }
 
@@ -129,6 +129,7 @@ class ListHabitsActivity : AppCompatActivity(), Preferences.Listener {
     }
 
     private fun parseIntents() {
+        if (intent == null) return
         if (intent.action == ACTION_EDIT) {
             val habitId = intent.extras?.getLong("habit")
             val timestamp = intent.extras?.getLong("timestamp")
@@ -137,6 +138,12 @@ class ListHabitsActivity : AppCompatActivity(), Preferences.Listener {
                 component.listHabitsBehavior.onEdit(habit, Timestamp(timestamp))
             }
         }
+        intent = null
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        setIntent(intent)
     }
 
     companion object {

--- a/uhabits-android/src/main/java/org/isoron/uhabits/intents/PendingIntentFactory.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/intents/PendingIntentFactory.kt
@@ -159,7 +159,7 @@ class PendingIntentFactory
     fun showNumberPicker(habit: Habit, timestamp: Timestamp): PendingIntent? {
         return getActivity(
             context,
-            0,
+            (habit.id!! % Integer.MAX_VALUE).toInt() + 1,
             Intent(context, ListHabitsActivity::class.java).apply {
                 action = ListHabitsActivity.ACTION_EDIT
                 putExtra("habit", habit.id)

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/StackWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/StackWidget.kt
@@ -73,6 +73,10 @@ class StackWidget(
             StackWidgetType.getStackWidgetAdapterViewId(widgetType),
             StackWidgetType.getStackWidgetEmptyViewId(widgetType)
         )
+        remoteViews.setPendingIntentTemplate(
+            StackWidgetType.getStackWidgetAdapterViewId(widgetType),
+            StackWidgetType.getPendingIntentTemplate(pendingIntentFactory, widgetType, habits)
+        )
         return remoteViews
     }
 }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/StackWidgetService.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/StackWidgetService.kt
@@ -57,7 +57,6 @@ internal class StackRemoteViewsFactory(private val context: Context, intent: Int
     )
     private val habitIds: LongArray
     private val widgetType: StackWidgetType
-    private var remoteViews = ArrayList<RemoteViews>()
     override fun onCreate() {}
     override fun onDestroy() {}
     override fun getCount(): Int {
@@ -89,7 +88,7 @@ internal class StackRemoteViewsFactory(private val context: Context, intent: Int
 
     override fun getViewAt(position: Int): RemoteViews? {
         Log.i("StackRemoteViewsFactory", "getViewAt $position started")
-        if (position < 0 || position >= remoteViews.size) return null
+        if (position < 0 || position >= habitIds.size) return null
         val app = context.applicationContext as HabitsApplication
         val prefs = app.component.preferences
         val habitList = app.component.habitList

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/StackWidgetType.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/StackWidgetType.kt
@@ -18,7 +18,12 @@
  */
 package org.isoron.uhabits.widgets
 
+import android.app.PendingIntent
+import android.content.Intent
 import org.isoron.uhabits.R
+import org.isoron.uhabits.core.models.Habit
+import org.isoron.uhabits.core.models.Timestamp
+import org.isoron.uhabits.intents.PendingIntentFactory
 import java.lang.IllegalStateException
 
 enum class StackWidgetType(val value: Int) {
@@ -71,6 +76,40 @@ enum class StackWidgetType(val value: Int) {
                 STREAKS -> R.id.streakStackWidgetEmptyView
                 TARGET -> R.id.targetStackWidgetEmptyView
                 else -> throw IllegalStateException()
+            }
+        }
+
+        fun getPendingIntentTemplate(
+            factory: PendingIntentFactory,
+            widgetType: StackWidgetType,
+            habits: List<Habit>
+        ): PendingIntent {
+            val containsNumerical = habits.any { it.isNumerical }
+            return when (widgetType) {
+                CHECKMARK -> if (containsNumerical) {
+                    factory.showNumberPickerTemplate()
+                } else {
+                    factory.toggleCheckmarkTemplate()
+                }
+                FREQUENCY, SCORE, HISTORY, STREAKS, TARGET -> factory.showHabitTemplate()
+            }
+        }
+
+        fun getIntentFillIn(
+            factory: PendingIntentFactory,
+            widgetType: StackWidgetType,
+            habit: Habit,
+            allHabitsInStackWidget: List<Habit>,
+            timestamp: Timestamp
+        ): Intent {
+            val containsNumerical = allHabitsInStackWidget.any { it.isNumerical }
+            return when (widgetType) {
+                CHECKMARK -> if (containsNumerical) {
+                    factory.showNumberPickerFillIn(habit, timestamp)
+                } else {
+                    factory.toggleCheckmarkFillIn(habit, timestamp)
+                }
+                FREQUENCY, SCORE, HISTORY, STREAKS, TARGET -> factory.showHabitFillIn(habit)
             }
         }
     }

--- a/uhabits-core/src/commonMain/kotlin/org/isoron/platform/utils/StringUtils.kt
+++ b/uhabits-core/src/commonMain/kotlin/org/isoron/platform/utils/StringUtils.kt
@@ -25,6 +25,12 @@ class StringUtils {
 
         fun joinLongs(values: LongArray): String = values.joinToString(separator = ",")
 
-        fun splitLongs(str: String): LongArray = str.split(",").map { it.toLong() }.toLongArray()
+        fun splitLongs(str: String): LongArray {
+            return try {
+                str.split(",").map { it.toLong() }.toLongArray()
+            } catch (e: NumberFormatException) {
+                LongArray(0)
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR implements some last-minute fixes related to widgets:

1. As mentioned in #1463, API 33 apparently requires us to use `setPendingIntentTemplate` and `setOnClickFillInIntent` instead of `setOnClickPendingIntent`, otherwise the clicks have no effect. This PR implements those changes.
   
   @hiqua Could you try it out and confirm that it has fixed the issue?
   
    Unfortunately this intent template system requires all widgets in the collection to have the same type of intent; so if one of the habits in the StackWidget is numerical (and therefore requires us to launch an activity with a number picker), then, from what I understand, **all** widgets in the stack must also launch an activity. One potential workaround would be to have all widgets launch a BroadcastReceiver, then the receiver could launch an activity conditionally, [but unfortunately this behavior is now also forbidden since API 32](https://developer.android.com/about/versions/12/behavior-changes-12#notification-trampolines).
4. This PR also fixes #1468
