### PR TITLE
fix marker scaling for numerical habits in frequency display

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/FrequencyChart.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/FrequencyChart.kt
@@ -238,8 +238,8 @@ class FrequencyChart : ScrollableChart {
         // maximal allowed mark radius
         val maxRadius = (rect.height() - 2 * padding) / 2.0f
         // the real mark radius is scaled down by a factor depending on the maximal frequency
-
-        val scale = 1.0f / frequency * valueCopy!!
+        val scalingFactor = if (isNumerical) maxFreq else weekdayFrequency
+        val scale = 1.0f / scalingFactor * valueCopy!!
         val radius = maxRadius * scale
         val colorIndex = min((colors.size - 1), ((colors.size - 1) * scale).roundToInt())
         pGraph!!.color = colors[colorIndex]

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/FrequencyChart.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/FrequencyChart.kt
@@ -63,6 +63,7 @@ class FrequencyChart : ScrollableChart {
     private var primaryColor = 0
     private var isBackgroundTransparent = false
     private lateinit var frequency: HashMap<Timestamp, Array<Int>>
+    private var maxFreq = 0
     private var firstWeekday = Calendar.SUNDAY
 
     constructor(context: Context?) : super(context) {
@@ -82,12 +83,22 @@ class FrequencyChart : ScrollableChart {
 
     fun setFrequency(frequency: java.util.HashMap<Timestamp, Array<Int>>) {
         this.frequency = frequency
+        maxFreq = getMaxFreq(frequency)
         postInvalidate()
     }
 
     fun setFirstWeekday(firstWeekday: Int) {
         this.firstWeekday = firstWeekday
         postInvalidate()
+    }
+
+    private fun getMaxFreq(frequency: HashMap<Timestamp, Array<Int>>): Int {
+        var maxValue = 1
+        for (values in frequency.values) for (value in values) maxValue = max(
+            value,
+            maxValue
+        )
+        return maxValue
     }
 
     fun setIsBackgroundTransparent(isBackgroundTransparent: Boolean) {
@@ -285,5 +296,6 @@ class FrequencyChart : ScrollableChart {
             frequency[Timestamp(date)] = values
             date.add(Calendar.MONTH, -1)
         }
+        maxFreq = getMaxFreq(frequency)
     }
 }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/FrequencyChart.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/FrequencyChart.kt
@@ -230,7 +230,7 @@ class FrequencyChart : ScrollableChart {
         canvas.drawLine(rGrid.left, rGrid.top, rGrid.right, rGrid.top, pGrid!!)
     }
 
-    private fun drawMarker(canvas: Canvas, rect: RectF?, value: Int?, frequency: Int) {
+    private fun drawMarker(canvas: Canvas, rect: RectF?, value: Int?, weekdayFrequency: Int) {
         // value can be negative when the entry is skipped
         val valueCopy = value?.let { max(0, it) }
 

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/FrequencyChart.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/FrequencyChart.kt
@@ -65,6 +65,7 @@ class FrequencyChart : ScrollableChart {
     private lateinit var frequency: HashMap<Timestamp, Array<Int>>
     private var maxFreq = 0
     private var firstWeekday = Calendar.SUNDAY
+    private var isNumerical: Boolean = false
 
     constructor(context: Context?) : super(context) {
         init()
@@ -78,6 +79,11 @@ class FrequencyChart : ScrollableChart {
     fun setColor(color: Int) {
         primaryColor = color
         initColors()
+        postInvalidate()
+    }
+
+    fun setIsNumerical(type: Boolean) {
+        isNumerical = type
         postInvalidate()
     }
 

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/views/FrequencyCardView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/views/FrequencyCardView.kt
@@ -33,6 +33,7 @@ class FrequencyCardView(context: Context, attrs: AttributeSet) : LinearLayout(co
     fun setState(state: FrequencyCardState) {
         val androidColor = state.theme.color(state.color).toInt()
         binding.frequencyChart.setFrequency(state.frequency)
+        binding.frequencyChart.setIsNumerical(state.isNumerical)
         binding.frequencyChart.setFirstWeekday(state.firstWeekday)
         binding.title.setTextColor(androidColor)
         binding.frequencyChart.setColor(androidColor)

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/FrequencyWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/FrequencyWidget.kt
@@ -49,6 +49,7 @@ class FrequencyWidget(
         (widgetView.dataView as FrequencyChart).apply {
             setFirstWeekday(firstWeekday)
             setColor(WidgetTheme().color(habit.color).toInt())
+            setIsNumerical(habit.isNumerical)
             setFrequency(habit.originalEntries.computeWeekdayFrequency(habit.isNumerical))
         }
     }

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/show/views/FrequencyCard.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/show/views/FrequencyCard.kt
@@ -30,6 +30,7 @@ data class FrequencyCardState(
     val firstWeekday: Int,
     val frequency: HashMap<Timestamp, Array<Int>>,
     val theme: Theme,
+    val isNumerical: Boolean
 )
 
 class FrequencyCardPresenter {
@@ -40,6 +41,7 @@ class FrequencyCardPresenter {
             theme: Theme
         ) = FrequencyCardState(
             color = habit.color,
+            isNumerical = habit.isNumerical,
             frequency = habit.originalEntries.computeWeekdayFrequency(
                 isNumerical = habit.isNumerical
             ),


### PR DESCRIPTION
Follow up to: #1425

The scaling was broken because inside the FrequencyChart class, the freq HashMap for numerical habits contains the achieved target for each day, so each value could be greater than 1. So the logic to normalize the scaling for Yes or No habits did not apply here.

I thought the best solution would be to restore the previous scaling logic, where the maximum frequency is used to scale the markers, only for numerical habits. That way you can visualize the days when you achieved a higher number, even if that number surpasses your target. If you only want to know if you reached your target, the calendar display does a great job already. 

Summarizing, for numerical habits, the frequency display allows you to visualize the actual values you reached, and the calendar display allows you to visualize if you reached your target or not.