### PR TITLE
Remove dependency on kotlin stdlib

### DIFF
--- a/uhabits-core/build.gradle.kts
+++ b/uhabits-core/build.gradle.kts
@@ -45,7 +45,6 @@ kotlin {
                 implementation(kotlin("stdlib-jdk8"))
                 compileOnly("com.google.dagger:dagger:2.44.2")
                 implementation("com.google.guava:guava:31.1-android")
-                implementation("org.jetbrains.kotlin:kotlin-stdlib:1.7.21")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4")
                 implementation("androidx.annotation:annotation:1.5.0")
                 implementation("com.google.code.findbugs:jsr305:3.0.2")


### PR DESCRIPTION
According to:
https://kotlinlang.org/docs/whatsnew14.html#dependency-on-the-standard-library-added-by-default the explicit dependency is no longer needed.