### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Check out source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: Build project
       run: ./build.sh build


### PR DESCRIPTION
Bump checkout to v3 because nodejs 12 is deprecated
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/