### PR TITLE
Add "github-actions" ecosystem to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
I've seen #1715, and since @dependabot can handle GitHub actions too, I made this PR to add the `github-actions` ecosystem to `dependabot.yml`.