### PR TITLE
Fixed Use of hardcoded US locale for BarChart

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/views/BarCardView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/views/BarCardView.kt
@@ -38,7 +38,7 @@ class BarCardView(context: Context, attrs: AttributeSet) : LinearLayout(context,
 
     fun setState(state: BarCardState) {
         val androidColor = state.theme.color(state.color).toInt()
-        binding.chart.view = BarChart(state.theme, JavaLocalDateFormatter(Locale.US)).apply {
+        binding.chart.view = BarChart(state.theme, JavaLocalDateFormatter(Locale.getDefault())).apply {
             series = mutableListOf(state.entries.map { it.value / 1000.0 })
             colors = mutableListOf(theme.color(state.color.paletteIndex))
             axis = state.entries.map { it.timestamp.toLocalDate() }


### PR DESCRIPTION
The selected locale (here `DE`) is not used in the BarChart, but instead `US` is used:
![BarChart_DE_bug](https://github.com/iSoron/uhabits/assets/40503329/4081f3bc-e67e-44b1-b6cb-fe4641899bda)

When replacing the hard-coded `Locale.US` with `Locale.getDefault()`, the correct short month names are shown:
![BarChart_DE_fixed](https://github.com/iSoron/uhabits/assets/40503329/6ab51e90-61a2-4b9c-85b8-4e09b2b7e1db)
