### PR TITLE
Make AGP version explicit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     val kotlinVersion = "1.7.21"
-    id("com.android.application") version ("7.4.2") apply (false)
+    id("com.android.application") version "7.4.2" apply (false)
     id("org.jetbrains.kotlin.android") version kotlinVersion apply (false)
     id("org.jetbrains.kotlin.kapt") version kotlinVersion apply (false)
     id("org.jetbrains.kotlin.android.extensions") version kotlinVersion apply (false)

--- a/uhabits-android/build.gradle.kts
+++ b/uhabits-android/build.gradle.kts
@@ -19,7 +19,7 @@
 
 plugins {
     id("com.github.triplet.play") version "3.7.0"
-    id("com.android.application")
+    id("com.android.application") version "7.4.2"
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.kapt")
     id("org.jetbrains.kotlin.android.extensions")


### PR DESCRIPTION
This makes it possible to run the AGP upgrade assistant from Android Studio.