### PR TITLE
Checkmark widget: to tint color on automatic days and hide ring view

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/RingView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/RingView.kt
@@ -215,4 +215,16 @@ class RingView : View {
     companion object {
         val XFERMODE_CLEAR = PorterDuffXfermode(PorterDuff.Mode.CLEAR)
     }
+
+    fun hide() {
+        this.visibility = GONE
+    }
+
+    fun show() {
+        this.visibility = VISIBLE
+    }
+
+    fun makeInvisible(){
+        this.visibility = INVISIBLE
+    }
 }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/views/CheckmarkWidgetView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/views/CheckmarkWidgetView.kt
@@ -23,6 +23,10 @@ import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.View
 import android.widget.TextView
+import androidx.core.graphics.ColorUtils.blendARGB
+import com.google.android.material.color.utilities.MathUtils.lerp
+import org.isoron.platform.gui.Color
+import org.isoron.platform.gui.toInt
 import org.isoron.uhabits.HabitsApplication
 import org.isoron.uhabits.R
 import org.isoron.uhabits.activities.common.views.RingView
@@ -67,21 +71,26 @@ class CheckmarkWidgetView : HabitWidgetView {
         val bgColor: Int
         val fgColor: Int
         setShadowAlpha(0x4f)
-        when (entryState) {
-            YES_MANUAL, SKIP -> {
-                bgColor = activeColor
-                fgColor = res.getColor(R.attr.contrast0)
-                backgroundPaint!!.color = bgColor
-                frame!!.setBackgroundDrawable(background)
-            }
-            YES_AUTO, NO, UNKNOWN -> {
-                bgColor = res.getColor(R.attr.cardBgColor)
-                fgColor = res.getColor(R.attr.contrast60)
-            }
-            else -> {
-                bgColor = res.getColor(R.attr.cardBgColor)
-                fgColor = res.getColor(R.attr.contrast60)
-            }
+
+        if(entryState == YES_MANUAL || entryState == SKIP) {
+            bgColor = activeColor
+            fgColor = res.getColor(R.attr.contrast0)
+            backgroundPaint!!.color = bgColor
+            frame!!.setBackgroundDrawable(background)
+        } else if(preferences!!.widgetCheckmarkTinting && entryState == YES_AUTO) {
+            bgColor = blendARGB(activeColor, res.getColor(R.attr.cardBgColor), 0.5f)
+            fgColor = res.getColor(R.attr.contrast0)
+            backgroundPaint!!.color = bgColor
+            frame!!.setBackgroundDrawable(background)
+        } else {
+            bgColor = res.getColor(R.attr.cardBgColor)
+            fgColor = res.getColor(R.attr.contrast60)
+        }
+
+        if(preferences!!.widgetCheckmarkHideRing) {
+            ring.hide()
+        } else {
+            ring.show()
         }
         ring.setPercentage(percentage)
         ring.setColor(fgColor)

--- a/uhabits-android/src/main/res/values/strings.xml
+++ b/uhabits-android/src/main/res/values/strings.xml
@@ -233,4 +233,8 @@
     <string name="activity_not_found">No app was found to support this action</string>
     <string name="pref_midnight_delay_title">Extend day a few hours past midnight</string>
     <string name="pref_midnight_delay_description">Wait until 3:00 AM to show a new day. Useful if you typically go to sleep after midnight. Requires app restart.</string>
+    <string name="pref_checkmark_tinting">Checkmark widget tinting</string>
+    <string name="pref_checkmark_tinting_summary">Tints the checkmark widget on days where a habit is paused or auto-filled.</string>
+    <string name="pref_checkmark_hide_ring_summary">Hides the ring display within the checkmark widget.</string>
+    <string name="pref_checkmark_hide_ring">Hide ring in checkmark widget</string>
 </resources>

--- a/uhabits-android/src/main/res/xml/preferences.xml
+++ b/uhabits-android/src/main/res/xml/preferences.xml
@@ -76,6 +76,24 @@
                 android:title="@string/widget_opacity_title"
                 app:iconSpaceReserved="false" />
 
+        <SwitchPreferenceCompat
+            android:id="@+id/switchPreferenceCheckmarkTinting"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="false"
+            android:key="pref_widget_checkmark_tint"
+            android:summary="@string/pref_checkmark_tinting_summary"
+            android:title="@string/pref_checkmark_tinting"
+            app:iconSpaceReserved="false" />
+        <SwitchPreferenceCompat
+            android:id="@+id/switchPreferenceCheckmarkHideRing"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="false"
+            android:key="pref_widget_checkmark_hide_ring"
+            android:summary="@string/pref_checkmark_hide_ring_summary"
+            android:title="@string/pref_checkmark_hide_ring"
+            app:iconSpaceReserved="false" />
         <ListPreference
                 android:key="pref_first_weekday"
                 android:title="@string/first_day_of_the_week"

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/preferences/Preferences.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/preferences/Preferences.kt
@@ -192,6 +192,16 @@ open class Preferences(private val storage: Storage) {
         set(value) {
             storage.putString("pref_widget_opacity", value.toString())
         }
+    var widgetCheckmarkTinting: Boolean
+        get() = storage.getBoolean("pref_widget_checkmark_tint", false)
+        set(checkmarkTinting) {
+            storage.putBoolean("pref_widget_checkmark_tint", checkmarkTinting)
+        }
+    var widgetCheckmarkHideRing: Boolean
+        get() = storage.getBoolean("pref_widget_checkmark_hide_ring", false)
+        set(checkmarkHideRing) {
+            storage.putBoolean("pref_widget_checkmark_hide_ring", checkmarkHideRing)
+        }
     var isSkipEnabled: Boolean
         get() = storage.getBoolean("pref_skip_enabled", false)
         set(value) {


### PR DESCRIPTION
Hi there, this is my first-ever pull request so I hope I am doing it right!

I added the functionality for the checkmark widget to appear as completed, albeit tinted, on days where a habit is paused. I have a "do sport every 3 days" habit - on the day I do sport it's green, and now on the 2 rest days is grey-green and doesn't show up as "do sport today!" on my home screen.

I also added the functionality to hide the ring view. Mainly because I don't understand what it even displays for all my habits, and the checkmark/X display is redundant with the background color. This way, it's a clearer design in my opinion.

I added both as options in the options menu and added strings for their descriptions. 

As I said, this is my first pull request ever so let me know how I am doing :-)