### PR TITLE
Unset measurable habits

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/NumberDialog.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/NumberDialog.kt
@@ -93,7 +93,11 @@ class NumberDialog : AppCompatDialogFragment() {
         try {
             val numberFormat = NumberFormat.getInstance()
             val valueStr = view.value.text.toString()
-            value = numberFormat.parse(valueStr)!!.toDouble()
+            value = if (valueStr.isNotEmpty()) {
+                numberFormat.parse(valueStr)!!.toDouble()
+            } else {
+                Entry.UNKNOWN.toDouble() / 1000
+            }
         } catch (e: ParseException) {
             // NOP
         }


### PR DESCRIPTION
I couldn't figure out a way to unset a measurable habit so I created this PR. If the save button is tapped in NumberDialog and the value is empty, the entry is saved as Entry.UNKNOWN. I've done it in line with how Entry.SKIP is saved.

Addresses #1722.