### PR TITLE
Implicit Check widget color

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/RingView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/RingView.kt
@@ -58,6 +58,7 @@ class RingView : View {
     private var em = 0f
     private var text: String?
     private var textSize: Float
+    private var isStrokedTextEnabled: Boolean = false
     private var enableFontAwesome = false
     private var internalDrawingCache: Bitmap? = null
     private var cacheCanvas: Canvas? = null
@@ -131,6 +132,10 @@ class RingView : View {
         invalidate()
     }
 
+    fun setIsStrokedTextEnabled(isStroked: Boolean) {
+        this.isStrokedTextEnabled = isStroked
+    }
+
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
         val activeCanvas: Canvas?
@@ -152,19 +157,25 @@ class RingView : View {
                 pRing!!.xfermode = XFERMODE_CLEAR
             } else {
                 pRing!!.color =
-                    backgroundColor!!
+                        backgroundColor!!
             }
             rect!!.inset(thickness, thickness)
             activeCanvas.drawArc(rect!!, 0f, 360f, true, pRing!!)
             pRing!!.xfermode = null
             pRing!!.color = color
             pRing!!.textSize = textSize
+
+            if (isStrokedTextEnabled){
+                pRing!!.style = Paint.Style.STROKE
+                pRing!!.strokeWidth = textSize / 15f
+            }
+
             if (enableFontAwesome) pRing!!.typeface = getFontAwesome(context)
             activeCanvas.drawText(
-                text!!,
-                rect!!.centerX(),
-                rect!!.centerY() + 0.4f * em,
-                pRing!!
+                    text!!,
+                    rect!!.centerX(),
+                    rect!!.centerY() + 0.4f * em,
+                    pRing!!
             )
         }
         if (activeCanvas !== canvas) canvas.drawBitmap(internalDrawingCache!!, 0f, 0f, null)

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/views/CheckmarkWidgetView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/views/CheckmarkWidgetView.kt
@@ -68,13 +68,13 @@ class CheckmarkWidgetView : HabitWidgetView {
         val fgColor: Int
         setShadowAlpha(0x4f)
         when (entryState) {
-            YES_MANUAL, SKIP -> {
+            YES_MANUAL, SKIP, YES_AUTO -> {
                 bgColor = activeColor
                 fgColor = res.getColor(R.attr.contrast0)
                 backgroundPaint!!.color = bgColor
                 frame!!.setBackgroundDrawable(background)
             }
-            YES_AUTO, NO, UNKNOWN -> {
+            NO, UNKNOWN -> {
                 bgColor = res.getColor(R.attr.cardBgColor)
                 fgColor = res.getColor(R.attr.contrast60)
             }
@@ -87,11 +87,22 @@ class CheckmarkWidgetView : HabitWidgetView {
         ring.setColor(fgColor)
         ring.setBackgroundColor(bgColor)
         ring.setText(text)
+        ring.setIsStrokedTextEnabled(strokedTextEnabled)
         label.text = name
         label.setTextColor(fgColor)
         requestLayout()
         postInvalidate()
     }
+
+    private val strokedTextEnabled: Boolean
+        get() = if (isNumerical) {
+            false
+        } else {
+            when (entryState) {
+                YES_AUTO -> true
+                else -> false
+            }
+        }
 
     private val text: String
         get() = if (isNumerical) {
@@ -135,14 +146,14 @@ class CheckmarkWidgetView : HabitWidgetView {
         }
         ring.setThickness(0.03f * width)
         super.onMeasure(
-            MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
-            MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
+                MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
         )
     }
 
     private fun init() {
         val appComponent: HabitsApplicationComponent =
-            (context.applicationContext as HabitsApplication).component
+                (context.applicationContext as HabitsApplication).component
         preferences = appComponent.preferences
         ring = findViewById<View>(R.id.scoreRing) as RingView
         label = findViewById<View>(R.id.label) as TextView


### PR DESCRIPTION
As discussed in #615, I have implemented that the background color of the checkmark widget on implicit check (auto check) is now filled (colored background) like on manual check, but has an empty/stroked checkmark instead of a filled one. 

I have no experience with Kotlin/App-development but I tried to copy the patterns as best I could. It is a really small change and it seems to work, though I did only test it manually.

Basically, I only added the YES_AUTO to the same background color when-branch as YES_MANUAL and added an option to the RingView to make it draw the text as stroked with a stroke width dependent on the text size.

This is what it looks like now:
![uhabits](https://github.com/iSoron/uhabits/assets/38957411/d73b0465-06b9-4b83-9c3b-be60f43231fc)
