### PR TITLE
Fix SKIP behavior in YES_AUTO and score

### DIFF
--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/EntryList.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/EntryList.kt
@@ -249,12 +249,14 @@ open class EntryList {
             entries: List<Entry>
         ): ArrayList<Interval> {
             val filtered = entries.filter { it.value == YES_MANUAL }
+            val skips = entries.filter { it.value == SKIP }
             val num = freq.numerator
             val den = freq.denominator
             val intervals = arrayListOf<Interval>()
             for (i in num - 1 until filtered.size) {
                 val (begin, _) = filtered[i]
                 val (center, _) = filtered[i - num + 1]
+                val skipCounts = skips.filter { it.timestamp in begin..center }.size
                 var size = den
                 if (den == 30 || den == 31) {
                     val beginDate = begin.toLocalDate()
@@ -264,8 +266,8 @@ open class EntryList {
                         beginDate.monthLength
                     }
                 }
-                if (begin.daysUntil(center) < size) {
-                    val end = begin.plus(size - 1)
+                if (begin.daysUntil(center) - skipCounts < size) {
+                    val end = begin.plus(size - 1 + skipCounts)
                     intervals.add(Interval(begin, center, end))
                 }
             }


### PR DESCRIPTION
I've had some SKIPs over the Christmas holidays and noticed the score was more punishing than expected. I have a habit setup to be done three times every week. I expect that if I have skipped some days, they will be treated as non-existent days, and occurrences around them will connect. This is not what happens, though:
![current](https://github.com/iSoron/uhabits/assets/3768676/69e93116-9cef-49d5-9b7d-6d016c737671)
As you can see doing two occurrences and skipping the end of the week, doesn't count next week's occurence as the third in the chain, because it's too far away in the expected range. By changing the logic to treat skip_days as not existent days you can keep the habit going without being punished for having half-weeks + skips:
![fixed](https://github.com/iSoron/uhabits/assets/3768676/42c3e07f-8626-4fff-a6df-87958cee912e)

This affects both YES_AUTO and the actual score calculation.
@iSoron if you agree this should be fixed, I can update/write tests to cover it.

This behaviour has been mentioned before here: 
https://github.com/iSoron/uhabits/discussions/1686