### PR TITLE
#1941 DateUtils test fix

### DIFF
--- a/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/utils/DateUtilsTest.kt
+++ b/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/utils/DateUtilsTest.kt
@@ -120,10 +120,16 @@ class DateUtilsTest : BaseUnitTest() {
 
     @Test
     fun getWeekdaysInMonth() {
-        val february = GregorianCalendar(2018, Calendar.FEBRUARY, 1)
-        val leapFebruary = GregorianCalendar(2020, Calendar.FEBRUARY, 1)
-        val month = GregorianCalendar(2020, Calendar.APRIL, 1)
-        val longMonth = GregorianCalendar(2020, Calendar.AUGUST, 1)
+        fun getCalendarUTC(year: Int, month: Int, dayOfMonth: Int): GregorianCalendar {
+            val gregCalendar = GregorianCalendar(year, month, dayOfMonth)
+            gregCalendar.timeZone = TimeZone.getTimeZone("UTC")
+            return gregCalendar
+        }
+
+        val february = getCalendarUTC(2018, Calendar.FEBRUARY, 1)
+        val leapFebruary = getCalendarUTC(2020, Calendar.FEBRUARY, 1)
+        val month = getCalendarUTC(2020, Calendar.APRIL, 1)
+        val longMonth = getCalendarUTC(2020, Calendar.AUGUST, 1)
 
         assertThat(
             arrayOf(4, 4, 4, 4, 4, 4, 4),

--- a/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/utils/DateUtilsTest.kt
+++ b/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/utils/DateUtilsTest.kt
@@ -120,11 +120,10 @@ class DateUtilsTest : BaseUnitTest() {
 
     @Test
     fun getWeekdaysInMonth() {
-        fun getCalendarUTC(year: Int, month: Int, dayOfMonth: Int): GregorianCalendar {
-            val gregCalendar = GregorianCalendar(year, month, dayOfMonth)
-            gregCalendar.timeZone = TimeZone.getTimeZone("UTC")
-            return gregCalendar
-        }
+        fun getCalendarUTC(year: Int, month: Int, dayOfMonth: Int) =
+            GregorianCalendar(year, month, dayOfMonth).apply {
+                timeZone = TimeZone.getTimeZone("UTC")
+            }
 
         val february = getCalendarUTC(2018, Calendar.FEBRUARY, 1)
         val leapFebruary = getCalendarUTC(2020, Calendar.FEBRUARY, 1)


### PR DESCRIPTION
Making GregorianCalendars go UTC to fix TimeZone issues.

Closes #1941.