### PR TITLE
Fix the misalignment of "About" page in RTL language

### DIFF
--- a/uhabits-android/src/main/res/values/styles.xml
+++ b/uhabits-android/src/main/res/values/styles.xml
@@ -226,6 +226,7 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:paddingTop">6dp</item>
         <item name="android:paddingBottom">6dp</item>
+        <item name="android:textAlignment">viewStart</item>
     </style>
 
     <style name="About.Item.Language">
@@ -233,6 +234,7 @@
         <item name="android:textSize">@dimen/smallTextSize</item>
         <item name="android:gravity">center</item>
         <item name="android:background">?attr/contrast20</item>
+        <item name="android:textAlignment">viewStart</item>
     </style>
 
     <style name="About.Item.Clickable">


### PR DESCRIPTION
Hi,

I just found a bug related to the About page in Arabic.
Page in English

<img width="179" alt="image" src="https://github.com/user-attachments/assets/700c06ed-6eb7-4772-95de-0db97ca1a973">

Page in Arabic

<img width="174" alt="image" src="https://github.com/user-attachments/assets/e8d004ca-5e17-4c8a-99b5-d84515c656b2">

The root cause is that you did not put android:textAlignment="start" in the textview. This pull request fixed this issue. Now it looks good.

<img width="177" alt="image" src="https://github.com/user-attachments/assets/d7637920-bc38-4594-b744-4b0644862a15">
