### PR TITLE
Never mark AT_MOST habits as completed for today

### DIFF
--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/Habit.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/Habit.kt
@@ -61,7 +61,7 @@ data class Habit(
         return if (isNumerical) {
             when (targetType) {
                 NumericalHabitType.AT_LEAST -> value / 1000.0 >= targetValue
-                NumericalHabitType.AT_MOST -> value != Entry.UNKNOWN && value / 1000.0 <= targetValue
+                NumericalHabitType.AT_MOST -> false
             }
         } else {
             value != Entry.NO && value != Entry.UNKNOWN

--- a/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/models/HabitTest.kt
+++ b/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/models/HabitTest.kt
@@ -110,10 +110,10 @@ class HabitTest : BaseUnitTest() {
         assertFalse(h.isCompletedToday())
         h.originalEntries.add(Entry(getToday(), 100000))
         h.recompute()
-        assertTrue(h.isCompletedToday())
+        assertFalse(h.isCompletedToday())
         h.originalEntries.add(Entry(getToday(), 50000))
         h.recompute()
-        assertTrue(h.isCompletedToday())
+        assertFalse(h.isCompletedToday())
     }
 
     @Test


### PR DESCRIPTION
This is a fix for #1744 and #2044. AT_MOST measurable habits are no longer marked as isCompletedToday().