### PR TITLE
Ignoring isCompleted for AT_MOST habits

### DIFF
--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/NotificationTray.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/NotificationTray.kt
@@ -24,6 +24,7 @@ import org.isoron.uhabits.core.commands.CommandRunner
 import org.isoron.uhabits.core.commands.CreateRepetitionCommand
 import org.isoron.uhabits.core.commands.DeleteHabitsCommand
 import org.isoron.uhabits.core.models.Habit
+import org.isoron.uhabits.core.models.NumericalHabitType
 import org.isoron.uhabits.core.models.Timestamp
 import org.isoron.uhabits.core.preferences.Preferences
 import org.isoron.uhabits.core.tasks.Task
@@ -120,7 +121,7 @@ class NotificationTray @Inject constructor(
 
         override fun onPostExecute() {
             systemTray.log("Showing notification for habit=" + habit.id)
-            if (isCompleted) {
+            if (isCompleted && habit.targetType != NumericalHabitType.AT_MOST) {
                 systemTray.log(
                     String.format(
                         Locale.US,


### PR DESCRIPTION
A fix for #2044. Excluding AT_MOST measurable habits from being treated as completed for today. This prevents skipping reminder notifications.