### PR TITLE
Adding clear past entries feature (minor change)

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/ShowHabitMenu.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/ShowHabitMenu.kt
@@ -56,6 +56,10 @@ class ShowHabitMenu(
                 presenter.onExportCSV()
                 return true
             }
+            R.id.action_clearEntries -> {
+                presenter.onClearEntries()
+                return true
+            }
         }
         return false
     }

--- a/uhabits-android/src/main/res/menu/show_habit.xml
+++ b/uhabits-android/src/main/res/menu/show_habit.xml
@@ -43,4 +43,9 @@
         android:visible="false"
         app:showAsAction="never"/>
 
+    <item
+        android:id="@+id/action_clearEntries"
+        android:title="@string/clear_entries"
+         app:showAsAction="never"/>
+
 </menu>

--- a/uhabits-android/src/main/res/values/strings.xml
+++ b/uhabits-android/src/main/res/values/strings.xml
@@ -233,4 +233,5 @@
     <string name="activity_not_found">No app was found to support this action</string>
     <string name="pref_midnight_delay_title">Extend day a few hours past midnight</string>
     <string name="pref_midnight_delay_description">Wait until 3:00 AM to show a new day. Useful if you typically go to sleep after midnight. Requires app restart.</string>
+    <string name="clear_entries">Clear Entries</string>
 </resources>

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/show/ShowHabitMenuPresenter.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/show/ShowHabitMenuPresenter.kt
@@ -64,6 +64,12 @@ class ShowHabitMenuPresenter(
         }
     }
 
+    fun onClearEntries() {
+        habit.originalEntries.clear()
+        habit.recompute()
+        screen.refresh()
+    }
+
     fun onRandomize() {
         val random = Random()
         habit.originalEntries.clear()


### PR DESCRIPTION
This can be added to clear the entries of a habit added by user instead of deleting a habit entirely.
Although, I know this is subjective and can have other opinions as well, other refinements are welcome. 

Reason: I once came across a scenario where I didn't want to delete the entire habit. but instead clear the entries so I can remove old data of that habit and wanted to start it over. 

Here's the feature:
(work is still in progress, it's not fully tested).


https://github.com/user-attachments/assets/38103954-00bc-4a25-ad4b-c07c457d3b6e

