### PR TITLE
Option to inverse checkmark widget On/Off colours

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/preferences/SharedPreferencesStorage.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/preferences/SharedPreferencesStorage.kt
@@ -93,6 +93,8 @@ class SharedPreferencesStorage
             "pref_unknown_enabled" -> {
                 preferences.areQuestionMarksEnabled = getBoolean(key, false)
             }
+            "pref_inverse_checkmark_colors" ->
+                preferences.isCheckmarkWidgetColorInverted = getBoolean(key, false)
         }
         sharedPreferences.registerOnSharedPreferenceChangeListener(this)
     }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/views/CheckmarkWidgetView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/views/CheckmarkWidgetView.kt
@@ -67,20 +67,45 @@ class CheckmarkWidgetView : HabitWidgetView {
         val bgColor: Int
         val fgColor: Int
         setShadowAlpha(0x4f)
-        when (entryState) {
-            YES_MANUAL, SKIP, YES_AUTO -> {
-                bgColor = activeColor
-                fgColor = res.getColor(R.attr.contrast0)
-                backgroundPaint!!.color = bgColor
-                frame!!.setBackgroundDrawable(background)
+        if (preferences!!.isCheckmarkWidgetColorInverted) {
+            when (entryState) {
+                YES_MANUAL, SKIP, YES_AUTO -> {
+                    bgColor = res.getColor(R.attr.cardBgColor)
+                    fgColor = res.getColor(R.attr.contrast60)
+                }
+
+                NO, UNKNOWN -> {
+                    bgColor = activeColor
+                    fgColor = res.getColor(R.attr.contrast0)
+                    backgroundPaint!!.color = bgColor
+                    frame!!.setBackgroundDrawable(background)
+                }
+
+                else -> {
+                    bgColor = activeColor
+                    fgColor = res.getColor(R.attr.contrast0)
+                    backgroundPaint!!.color = bgColor
+                    frame!!.setBackgroundDrawable(background)
+                }
             }
-            NO, UNKNOWN -> {
-                bgColor = res.getColor(R.attr.cardBgColor)
-                fgColor = res.getColor(R.attr.contrast60)
-            }
-            else -> {
-                bgColor = res.getColor(R.attr.cardBgColor)
-                fgColor = res.getColor(R.attr.contrast60)
+        } else {
+            when (entryState) {
+                YES_MANUAL, SKIP, YES_AUTO -> {
+                    bgColor = activeColor
+                    fgColor = res.getColor(R.attr.contrast0)
+                    backgroundPaint!!.color = bgColor
+                    frame!!.setBackgroundDrawable(background)
+                }
+
+                NO, UNKNOWN -> {
+                    bgColor = res.getColor(R.attr.cardBgColor)
+                    fgColor = res.getColor(R.attr.contrast60)
+                }
+
+                else -> {
+                    bgColor = res.getColor(R.attr.cardBgColor)
+                    fgColor = res.getColor(R.attr.contrast60)
+                }
             }
         }
         ring.setPercentage(percentage)

--- a/uhabits-android/src/main/res/values/strings.xml
+++ b/uhabits-android/src/main/res/values/strings.xml
@@ -233,4 +233,6 @@
     <string name="activity_not_found">No app was found to support this action</string>
     <string name="pref_midnight_delay_title">Extend day a few hours past midnight</string>
     <string name="pref_midnight_delay_description">Wait until 3:00 AM to show a new day. Useful if you typically go to sleep after midnight. Requires app restart.</string>
+    <string name="pref_inverse_checkmark_colors_title">Inverse checkmark widget colors</string>
+    <string name="pref_inverse_checkmark_colors_description">Make the checkmark widget looked turn off once the task is done.</string>
 </resources>

--- a/uhabits-android/src/main/res/xml/preferences.xml
+++ b/uhabits-android/src/main/res/xml/preferences.xml
@@ -81,6 +81,13 @@
                 android:title="@string/first_day_of_the_week"
                 app:iconSpaceReserved="false" />
 
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="pref_inverse_checkmark_colors"
+            android:summary="@string/pref_inverse_checkmark_colors_description"
+            android:title="@string/pref_inverse_checkmark_colors_title"
+            app:iconSpaceReserved="false" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/preferences/Preferences.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/preferences/Preferences.kt
@@ -205,6 +205,13 @@ open class Preferences(private val storage: Storage) {
             for (l in listeners) l.onQuestionMarksChanged()
         }
 
+    var isCheckmarkWidgetColorInverted: Boolean
+        get() = storage.getBoolean("pref_inverse_checkmark_colors", false)
+        set(value) {
+            storage.putBoolean("pref_inverse_checkmark_colors", value)
+            for (l in listeners) l.onCheckmarkColorsChanged()
+        }
+
     /**
      * @return An integer representing the first day of the week. Sunday
      * corresponds to 1, Monday to 2, and so on, until Saturday, which is
@@ -237,6 +244,7 @@ open class Preferences(private val storage: Storage) {
         fun onCheckmarkSequenceChanged() {}
         fun onNotificationsChanged() {}
         fun onQuestionMarksChanged() {}
+        fun onCheckmarkColorsChanged() {}
     }
 
     interface Storage {


### PR DESCRIPTION
Implemented the feature discussed in #2091.
Added option to choose to invert the checkmark widgets colours, making the colourful version a call to action.

![Capture2](https://github.com/user-attachments/assets/2d59ae09-c1b2-4688-9f55-67f887c363ee)
![Capture](https://github.com/user-attachments/assets/2aeb729f-7e84-46a9-a167-871519eb218b)

I'm not 100% sure about the what colour the UNKNOWN state should be because I don't really understand when it happens. I kept it the same as NO.


I've never contributed in github or ever coded for android, so feel free to tell me if I did something wrong.
