### PR TITLE
Added 'UNKNOWN' button for measurable habits

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/NumberDialog.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/NumberDialog.kt
@@ -47,7 +47,7 @@ class NumberDialog : AppCompatDialogFragment() {
             it.typeface = InterfaceUtils.getFontAwesome(requireContext())
         }
         if (!prefs.isSkipEnabled) view.skipBtnNumber.visibility = View.GONE
-        if (!prefs.areQuestionMarksEnabled) view.unknownBtnNumber.visibility = View.GONE 
+        if (!prefs.areQuestionMarksEnabled) view.unknownBtnNumber.visibility = View.GONE
         view.numberButtons.visibility = View.VISIBLE
         fixDecimalSeparator(view)
         originalNotes = requireArguments().getString("notes")!!
@@ -100,8 +100,7 @@ class NumberDialog : AppCompatDialogFragment() {
 
         // https://github.com/flutter/flutter/issues/61175
         val currKeyboard = Settings.Secure.getString(
-            requireContext().contentResolver,
-            Settings.Secure.DEFAULT_INPUT_METHOD
+            requireContext().contentResolver, Settings.Secure.DEFAULT_INPUT_METHOD
         )
         if (currKeyboard.contains("swiftkey") || currKeyboard.contains("samsung")) {
             view.value.inputType = EditorInfo.TYPE_CLASS_TEXT

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/NumberDialog.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/NumberDialog.kt
@@ -13,7 +13,6 @@ import androidx.appcompat.app.AppCompatDialogFragment
 import org.isoron.uhabits.HabitsApplication
 import org.isoron.uhabits.R
 import org.isoron.uhabits.core.models.Entry
-import org.isoron.uhabits.core.models.Entry.Companion.UNKNOWN
 import org.isoron.uhabits.databinding.CheckmarkPopupBinding
 import org.isoron.uhabits.utils.InterfaceUtils
 import org.isoron.uhabits.utils.getCenter
@@ -100,7 +99,8 @@ class NumberDialog : AppCompatDialogFragment() {
 
         // https://github.com/flutter/flutter/issues/61175
         val currKeyboard = Settings.Secure.getString(
-            requireContext().contentResolver, Settings.Secure.DEFAULT_INPUT_METHOD
+            requireContext().contentResolver,
+            Settings.Secure.DEFAULT_INPUT_METHOD
         )
         if (currKeyboard.contains("swiftkey") || currKeyboard.contains("samsung")) {
             view.value.inputType = EditorInfo.TYPE_CLASS_TEXT

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/NumberDialog.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/NumberDialog.kt
@@ -13,6 +13,7 @@ import androidx.appcompat.app.AppCompatDialogFragment
 import org.isoron.uhabits.HabitsApplication
 import org.isoron.uhabits.R
 import org.isoron.uhabits.core.models.Entry
+import org.isoron.uhabits.core.models.Entry.Companion.UNKNOWN
 import org.isoron.uhabits.databinding.CheckmarkPopupBinding
 import org.isoron.uhabits.utils.InterfaceUtils
 import org.isoron.uhabits.utils.getCenter
@@ -36,16 +37,17 @@ class NumberDialog : AppCompatDialogFragment() {
         val appComponent = (requireActivity().application as HabitsApplication).component
         val prefs = appComponent.preferences
         view = CheckmarkPopupBinding.inflate(LayoutInflater.from(context))
-        arrayOf(view.yesBtn, view.skipBtn).forEach {
+        arrayOf(view.yesBtn).forEach {
             it.setTextColor(requireArguments().getInt("color"))
         }
-        arrayOf(view.noBtn, view.unknownBtn).forEach {
+        arrayOf(view.noBtn, view.unknownBtnNumber).forEach {
             it.setTextColor(view.root.sres.getColor(R.attr.contrast60))
         }
-        arrayOf(view.yesBtn, view.noBtn, view.skipBtn, view.unknownBtn).forEach {
+        arrayOf(view.yesBtn, view.noBtn, view.unknownBtnNumber).forEach {
             it.typeface = InterfaceUtils.getFontAwesome(requireContext())
         }
         if (!prefs.isSkipEnabled) view.skipBtnNumber.visibility = View.GONE
+        if (!prefs.areQuestionMarksEnabled) view.unknownBtnNumber.visibility = View.GONE 
         view.numberButtons.visibility = View.VISIBLE
         fixDecimalSeparator(view)
         originalNotes = requireArguments().getString("notes")!!
@@ -71,6 +73,12 @@ class NumberDialog : AppCompatDialogFragment() {
             view.value.setText(DecimalFormat("#.###").format((Entry.SKIP.toDouble() / 1000)))
             save()
         }
+
+        view.unknownBtnNumber.setOnClickListener {
+            view.value.setText(DecimalFormat("#.###").format((Entry.UNKNOWN.toDouble() / 1000)))
+            save()
+        }
+
         view.notes.setOnEditorActionListener { v, actionId, event ->
             save()
             true

--- a/uhabits-android/src/main/res/layout/checkmark_popup.xml
+++ b/uhabits-android/src/main/res/layout/checkmark_popup.xml
@@ -99,6 +99,11 @@
             android:text="@string/skip_day" />
 
         <TextView
+            android:id="@+id/unknownBtnNumber"
+            style="@style/CheckmarkPopupBtn"
+            android:text="@string/fa_question" />
+
+        <TextView
             android:id="@+id/saveBtn"
             style="@style/NumericalPopupBtn"
             android:text="@string/save" />

--- a/uhabits-android/src/main/res/layout/checkmark_popup.xml
+++ b/uhabits-android/src/main/res/layout/checkmark_popup.xml
@@ -23,32 +23,32 @@
     android:id="@+id/container"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:minHeight="128dp"
+    android:background="@drawable/checkmark_dialog_bg"
     android:minWidth="208dp"
-    app:divider="@drawable/checkmark_dialog_divider"
-    app:showDividers="middle"
+    android:minHeight="128dp"
     android:orientation="vertical"
-    android:background="@drawable/checkmark_dialog_bg">
+    app:divider="@drawable/checkmark_dialog_divider"
+    app:showDividers="middle">
 
     <androidx.appcompat.widget.AppCompatEditText
         android:id="@+id/notes"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:gravity="center"
-        android:inputType="textCapSentences|textMultiLine"
-        android:textSize="@dimen/smallTextSize"
-        android:padding="4dp"
         android:background="@color/transparent"
+        android:gravity="center"
         android:hint="@string/notes"
-        android:text="" />
+        android:inputType="textCapSentences|textMultiLine"
+        android:padding="4dp"
+        android:text=""
+        android:textSize="@dimen/smallTextSize" />
 
     <androidx.appcompat.widget.LinearLayoutCompat
         android:id="@+id/booleanButtons"
-        android:visibility="gone"
         android:layout_width="match_parent"
         android:layout_height="48dp"
         android:orientation="horizontal"
+        android:visibility="gone"
         app:divider="@drawable/checkmark_dialog_divider"
         app:showDividers="middle">
 
@@ -75,10 +75,10 @@
 
     <androidx.appcompat.widget.LinearLayoutCompat
         android:id="@+id/numberButtons"
-        android:visibility="gone"
         android:layout_width="match_parent"
         android:layout_height="48dp"
         android:orientation="horizontal"
+        android:visibility="gone"
         app:divider="@drawable/checkmark_dialog_divider"
         app:showDividers="middle">
 
@@ -88,9 +88,9 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:background="@color/transparent"
-            android:textAlignment="center"
             android:inputType="numberDecimal"
             android:selectAllOnFocus="true"
+            android:textAlignment="center"
             android:textSize="@dimen/smallTextSize" />
 
         <TextView


### PR DESCRIPTION
This solves #1857 and #1815 by enabling users to 'reset' an entry for a measurable habit if they added it by mistake. As this is not just a bug fix, but rather a new feature, I'll wait for an approval by @iSoron or @hiqua.