### PR TITLE
Save notes when dialog closes (screen rotation, screen turned off, user accidentally clicked outside the dialog)

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/CheckmarkDialog.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/CheckmarkDialog.kt
@@ -38,10 +38,13 @@ import org.isoron.uhabits.utils.sres
 class CheckmarkDialog : AppCompatDialogFragment() {
     var onToggle: (Int, String) -> Unit = { _, _ -> }
 
+    private var wasSaved = false
+    private lateinit var view: CheckmarkPopupBinding
+
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val appComponent = (requireActivity().application as HabitsApplication).component
         val prefs = appComponent.preferences
-        val view = CheckmarkPopupBinding.inflate(LayoutInflater.from(context))
+        view = CheckmarkPopupBinding.inflate(LayoutInflater.from(context))
         val color = requireArguments().getInt("color")
         arrayOf(view.yesBtn, view.skipBtn).forEach {
             it.setTextColor(color)
@@ -62,8 +65,7 @@ class CheckmarkDialog : AppCompatDialogFragment() {
             setBackgroundDrawableResource(android.R.color.transparent)
         }
         fun onClick(v: Int) {
-            val notes = view.notes.text.toString().trim()
-            onToggle(v, notes)
+            save(v)
             requireDialog().dismiss()
         }
         view.yesBtn.setOnClickListener { onClick(YES_MANUAL) }
@@ -76,5 +78,18 @@ class CheckmarkDialog : AppCompatDialogFragment() {
         }
 
         return dialog
+    }
+
+    override fun onDestroyView() {
+        if (!wasSaved) {
+            save(requireArguments().getInt("value"))
+        }
+        super.onDestroyView()
+    }
+
+    fun save(v: Int) {
+        val notes = view.notes.text.toString().trim()
+        onToggle(v, notes)
+        wasSaved = true
     }
 }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/NumberDialog.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/NumberDialog.kt
@@ -30,6 +30,7 @@ class NumberDialog : AppCompatDialogFragment() {
 
     private var originalNotes: String = ""
     private var originalValue: Double = 0.0
+    private var wasSaved = false
     private lateinit var view: CheckmarkPopupBinding
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
@@ -60,26 +61,26 @@ class NumberDialog : AppCompatDialogFragment() {
         )
         view.value.setOnKeyListener { _, keyCode, event ->
             if (event.action == MotionEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_ENTER) {
-                save()
+                saveAndDismiss()
                 return@setOnKeyListener true
             }
             return@setOnKeyListener false
         }
         view.saveBtn.setOnClickListener {
-            save()
+            saveAndDismiss()
         }
         view.skipBtnNumber.setOnClickListener {
             view.value.setText(DecimalFormat("#.###").format((Entry.SKIP.toDouble() / 1000)))
-            save()
+            saveAndDismiss()
         }
 
         view.unknownBtnNumber.setOnClickListener {
             view.value.setText(DecimalFormat("#.###").format((Entry.UNKNOWN.toDouble() / 1000)))
-            save()
+            saveAndDismiss()
         }
 
         view.notes.setOnEditorActionListener { v, actionId, event ->
-            save()
+            saveAndDismiss()
             true
         }
         view.value.requestFocusWithKeyboard()
@@ -90,6 +91,13 @@ class NumberDialog : AppCompatDialogFragment() {
         }
         dialog.setOnDismissListener { onDismiss() }
         return dialog
+    }
+
+    override fun onDestroyView() {
+        if (!wasSaved) {
+            save()
+        }
+        super.onDestroyView()
     }
 
     private fun fixDecimalSeparator(view: CheckmarkPopupBinding) {
@@ -105,6 +113,11 @@ class NumberDialog : AppCompatDialogFragment() {
         if (currKeyboard.contains("swiftkey") || currKeyboard.contains("samsung")) {
             view.value.inputType = EditorInfo.TYPE_CLASS_TEXT
         }
+    }
+
+    fun saveAndDismiss() {
+        save()
+        requireDialog().dismiss()
     }
 
     fun save() {
@@ -123,6 +136,6 @@ class NumberDialog : AppCompatDialogFragment() {
         val notes = view.notes.text.toString()
         val location = view.saveBtn.getCenter()
         onToggle(value, notes)
-        requireDialog().dismiss()
+        wasSaved = true
     }
 }


### PR DESCRIPTION
I extensively add notes to my tracked habits, and it's frustrating when my whole note disappears when I accidentally rotate the screen or my screen turns off.

I noticed that Dialogs are closed on purpose (`dismissCurrentDialog` in `onPause()`), because callbacks are cleared after rotation. Fixing it would involve architecture changes, so I added a quick fix instead to autosave notes when the dialog closes.