### PR TITLE
Fix(UI): X and ? symbols easier to distinguish in "pure black" dark mode

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/RingView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/RingView.kt
@@ -204,7 +204,7 @@ class RingView : View {
         val res = StyledResources(context)
         if (backgroundColor == null) backgroundColor = res.getColor(R.attr.cardBgColor)
         if (inactiveColor == null) inactiveColor = res.getColor(R.attr.contrast100)
-        inactiveColor = setAlpha(inactiveColor!!, 0.1f)
+        inactiveColor = setAlpha(inactiveColor!!, 0.15f)
         rect = RectF()
     }
 

--- a/uhabits-android/src/main/res/values/styles.xml
+++ b/uhabits-android/src/main/res/values/styles.xml
@@ -126,8 +126,9 @@
         <item name="highlightedBackgroundColor">@color/black</item>
         <item name="contrast0">@color/black</item>
         <item name="contrast20">@color/grey_900</item>
-        <item name="contrast60">@color/grey_700</item>
-        <item name="contrast80">@color/grey_700</item>
+        <item name="contrast40">@color/grey_800</item>
+        <item name="contrast60">@color/grey_500</item>
+        <item name="contrast80">@color/grey_400</item>
         <item name="contrast100">@color/grey_200</item>
         <item name="selectedBackground">@drawable/selected_box</item>
         <item name="textColorAlertDialogListItem">@color/grey_100</item>


### PR DESCRIPTION
In addition to that, make "progress ring" a bit more visible.

Closes: https://github.com/iSoron/uhabits/discussions/2102

# Before

![Screenshot_20250411_174914_Habits](https://github.com/user-attachments/assets/a68827c3-0b95-4bec-8e21-a1ef573f5359)

# After

![Screenshot_20250411_174503_Habits](https://github.com/user-attachments/assets/ae70c0fb-3be4-4fa5-a1da-466f12ce2f27)
