### PR TITLE
style: allow adding newlines in the "Name" field

### DIFF
--- a/uhabits-android/src/main/res/layout/activity_edit_habit.xml
+++ b/uhabits-android/src/main/res/layout/activity_edit_habit.xml
@@ -94,8 +94,9 @@
                         <EditText
                             android:id="@+id/nameInput"
                             style="@style/FormInput"
-                            android:maxLines="1"
-                            android:inputType="textCapSentences"
+                            android:maxLines="2"
+                            android:maxLength="50"
+                            android:inputType="textCapSentences|textMultiLine"
                             android:hint="@string/yes_or_no_short_example"
                             />
                     </LinearLayout>


### PR DESCRIPTION
Since habit names are already shown with 2 lines in the main view, it makes sense to allow an user to add newlines to the names. This opens up the possibility for having better formatted text for the habit name.
As suggested by another user, having markdown support would also be a good addition at some point.

Closes: https://github.com/iSoron/uhabits/discussions/2101

Before:

![Screenshot_20250412_192921_Habits](https://github.com/user-attachments/assets/13472892-a9dd-4614-9a92-da2a9a02193f)

After:

![Screenshot_20250412_193032_Habits](https://github.com/user-attachments/assets/c2f69b54-d42e-4932-bbdb-cfb9abfda7a9)
