### PR TITLE
New option that allows making completed/entered habits grey

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsActivity.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsActivity.kt
@@ -75,8 +75,12 @@ class ListHabitsActivity : AppCompatActivity(), Preferences.Listener {
     private lateinit var menu: ListHabitsMenu
 
     override fun onQuestionMarksChanged() {
-        invalidateOptionsMenu()
-        menu.behavior.onPreferencesChanged()
+        if (prefs.greyCompleted) {
+            restartWithFade(this::class.java)
+        } else {
+            invalidateOptionsMenu()
+            menu.behavior.onPreferencesChanged()
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsMenu.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsMenu.kt
@@ -49,13 +49,17 @@ class ListHabitsMenu @Inject constructor(
         val nightModeItem = menu.findItem(R.id.actionToggleNightMode)
         val hideArchivedItem = menu.findItem(R.id.actionHideArchived)
         val hideCompletedItem = menu.findItem(R.id.actionHideCompleted)
+        val greyCompletedItem = menu.findItem(R.id.actionGreyCompleted)
         nightModeItem.isChecked = themeSwitcher.isNightMode
         hideArchivedItem.isChecked = !preferences.showArchived
         hideCompletedItem.isChecked = !preferences.showCompleted
+        greyCompletedItem.isChecked = preferences.greyCompleted
         if (preferences.areQuestionMarksEnabled || preferences.isSkipEnabled) {
             hideCompletedItem.title = activity.resources.getString(R.string.hide_entered)
+            greyCompletedItem.title = activity.resources.getString(R.string.grey_entered)
         } else {
             hideCompletedItem.title = activity.resources.getString(R.string.hide_completed)
+            greyCompletedItem.title = activity.resources.getString(R.string.grey_completed)
         }
         updateArrows(menu)
     }
@@ -117,6 +121,12 @@ class ListHabitsMenu @Inject constructor(
 
             R.id.actionHideCompleted -> {
                 behavior.onToggleShowCompleted()
+                activity.invalidateOptionsMenu()
+                return true
+            }
+
+            R.id.actionGreyCompleted -> {
+                behavior.onToggleGreyCompleted()
                 activity.invalidateOptionsMenu()
                 return true
             }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/HabitCardView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/HabitCardView.kt
@@ -35,14 +35,17 @@ import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.TextView
 import org.isoron.platform.gui.toInt
+import org.isoron.uhabits.HabitsApplication
 import org.isoron.uhabits.R
 import org.isoron.uhabits.activities.common.views.RingView
 import org.isoron.uhabits.core.models.Habit
 import org.isoron.uhabits.core.models.ModelObservable
 import org.isoron.uhabits.core.models.Timestamp
+import org.isoron.uhabits.core.preferences.Preferences
 import org.isoron.uhabits.core.ui.screens.habits.list.ListHabitsBehavior
 import org.isoron.uhabits.core.utils.DateUtils
 import org.isoron.uhabits.inject.ActivityContext
+import org.isoron.uhabits.inject.HabitsApplicationComponent
 import org.isoron.uhabits.utils.currentTheme
 import org.isoron.uhabits.utils.dp
 import org.isoron.uhabits.utils.sres
@@ -123,7 +126,12 @@ class HabitCardView(
             numberPanel.notes = values
         }
 
+    private val appComponent: HabitsApplicationComponent =
+        (context.applicationContext as HabitsApplication).component
+    private val prefs: Preferences = appComponent.preferences
+
     var checkmarkPanel: CheckmarkPanelView
+
     private var numberPanel: NumberPanelView
     private var innerFrame: LinearLayout
     private var label: TextView
@@ -264,10 +272,19 @@ class HabitCardView(
 
     private fun copyAttributesFrom(h: Habit) {
         fun getActiveColor(habit: Habit): Int {
-            return when (habit.isArchived) {
-                true -> sres.getColor(R.attr.contrast60)
-                false -> currentTheme().color(habit.color).toInt()
+            var retCol: Int = currentTheme().color(habit.color).toInt()
+
+            if (habit.isArchived) {
+                retCol = sres.getColor(R.attr.contrast60)
+            } else if (prefs.greyCompleted) {
+                if (prefs.areQuestionMarksEnabled && habit.isEnteredToday()) {
+                    retCol = sres.getColor(R.attr.contrast40)
+                } else if (!prefs.areQuestionMarksEnabled && habit.isCompletedToday()) {
+                    retCol = sres.getColor(R.attr.contrast40)
+                }
             }
+
+            return retCol
         }
 
         val c = getActiveColor(h)

--- a/uhabits-android/src/main/res/menu/list_habits.xml
+++ b/uhabits-android/src/main/res/menu/list_habits.xml
@@ -48,6 +48,12 @@
                 android:enabled="true"
                 android:title="@string/hide_completed"/>
 
+            <item
+                android:id="@+id/actionGreyCompleted"
+                android:checkable="true"
+                android:enabled="true"
+                android:title="@string/grey_completed"/>
+
             <item android:title="@string/sort">
                 <menu>
                     <item

--- a/uhabits-android/src/main/res/values/strings.xml
+++ b/uhabits-android/src/main/res/values/strings.xml
@@ -161,7 +161,9 @@
     <string name="none">None</string>
     <string name="filter">Filter</string>
     <string name="hide_completed">Hide completed</string>
+    <string name="grey_completed">Grey completed</string>
     <string name="hide_entered">Hide entered</string>
+    <string name="grey_entered">Grey entered</string>
     <string name="hide_archived">Hide archived</string>
     <string name="sticky_notifications">Make notifications sticky</string>
     <string name="sticky_notifications_description">Prevents notifications from being swiped away.</string>

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/preferences/Preferences.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/preferences/Preferences.kt
@@ -101,6 +101,11 @@ open class Preferences(private val storage: Storage) {
         set(showCompleted) {
             storage.putBoolean("pref_show_completed", showCompleted)
         }
+    var greyCompleted: Boolean
+        get() = storage.getBoolean("pref_grey_completed", false)
+        set(greyCompleted) {
+            storage.putBoolean("pref_grey_completed", greyCompleted)
+        }
 
     var theme: Int
         get() = storage.getInt("pref_theme", ThemeSwitcher.THEME_AUTOMATIC)

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsMenuBehavior.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsMenuBehavior.kt
@@ -65,7 +65,7 @@ class ListHabitsMenuBehavior @Inject constructor(
     fun onToggleGreyCompleted() {
         greyCompleted = !greyCompleted
         preferences.greyCompleted = greyCompleted
-        updateAdapterFilter()
+        screen.applyTheme()
     }
 
     fun onSortByManually() {

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsMenuBehavior.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsMenuBehavior.kt
@@ -31,6 +31,7 @@ class ListHabitsMenuBehavior @Inject constructor(
     private val themeSwitcher: ThemeSwitcher
 ) {
     private var showCompleted: Boolean
+    private var greyCompleted: Boolean
     private var showArchived: Boolean
 
     fun onCreateHabit() {
@@ -58,6 +59,12 @@ class ListHabitsMenuBehavior @Inject constructor(
     fun onToggleShowCompleted() {
         showCompleted = !showCompleted
         preferences.showCompleted = showCompleted
+        updateAdapterFilter()
+    }
+
+    fun onToggleGreyCompleted() {
+        greyCompleted = !greyCompleted
+        preferences.greyCompleted = greyCompleted
         updateAdapterFilter()
     }
 
@@ -137,6 +144,7 @@ class ListHabitsMenuBehavior @Inject constructor(
 
     init {
         showCompleted = preferences.showCompleted
+        greyCompleted = preferences.greyCompleted
         showArchived = preferences.showArchived
         updateAdapterFilter()
     }

--- a/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/preferences/PreferencesTest.kt
+++ b/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/preferences/PreferencesTest.kt
@@ -156,10 +156,13 @@ class PreferencesTest : BaseUnitTest() {
     fun testFiltering() {
         assertFalse(prefs.showArchived)
         assertTrue(prefs.showCompleted)
+        assertFalse(prefs.greyCompleted)
         prefs.showArchived = true
         prefs.showCompleted = false
+        prefs.greyCompleted = true
         assertTrue(prefs.showArchived)
         assertFalse(prefs.showCompleted)
+        assertTrue(prefs.greyCompleted)
     }
 
     @Test


### PR DESCRIPTION
Works the same way as hiding habits, but only changes the color.

The reason this is useful, is because when a habit is treated as completed/entered, the cause might be just the frequency set for that habit.

So, if it's once per month and you've entered it only once, till a month has passed the habit will be hidden, but the habit might've been done again within that month and it would be useful to be able to see it to enter that data.

At some point it'll be good to change the darkest grey in the habit palet in "Edit habit", so that it doesn't conflict with the archived habit and "grey complete" colors.

It'll be good to call `finish()` on the settings activity, to avoid stacking activities every time the setting is changed.

Closes: https://github.com/iSoron/uhabits/discussions/2103

Option disabled:

![Screenshot_20250413_192622_Habits](https://github.com/user-attachments/assets/e9f7ddb4-6d30-4bc1-86be-f974216bee52)

Option enabled:

![Screenshot_20250413_192638_Habits](https://github.com/user-attachments/assets/aa69b608-0680-4830-8f7a-36da911a44ba)