### PR TITLE
fix(ui): hacky fix for updating colors on pure black setting change

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsActivity.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsActivity.kt
@@ -79,6 +79,10 @@ class ListHabitsActivity : AppCompatActivity(), Preferences.Listener {
         menu.behavior.onPreferencesChanged()
     }
 
+    override fun onPureBlackChanged() {
+        screen.applyTheme()
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/uhabits-android/src/main/java/org/isoron/uhabits/preferences/SharedPreferencesStorage.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/preferences/SharedPreferencesStorage.kt
@@ -90,9 +90,10 @@ class SharedPreferencesStorage
                 preferences.isMidnightDelayEnabled = getBoolean(key, false)
             "pref_sticky_notifications" ->
                 preferences.setNotificationsSticky(getBoolean(key, false))
-            "pref_unknown_enabled" -> {
+            "pref_unknown_enabled" ->
                 preferences.areQuestionMarksEnabled = getBoolean(key, false)
-            }
+            "pref_pure_black" ->
+                preferences.isPureBlackEnabled = getBoolean(key, false)
         }
         sharedPreferences.registerOnSharedPreferenceChangeListener(this)
     }

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/preferences/Preferences.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/preferences/Preferences.kt
@@ -128,6 +128,7 @@ open class Preferences(private val storage: Storage) {
         get() = storage.getBoolean("pref_pure_black", false)
         set(enabled) {
             storage.putBoolean("pref_pure_black", enabled)
+            for (l in listeners) l.onPureBlackChanged()
         }
     var isShortToggleEnabled: Boolean
         get() = storage.getBoolean("pref_short_toggle", false)
@@ -243,6 +244,7 @@ open class Preferences(private val storage: Storage) {
         fun onCheckmarkSequenceChanged() {}
         fun onNotificationsChanged() {}
         fun onQuestionMarksChanged() {}
+        fun onPureBlackChanged() {}
     }
 
     interface Storage {


### PR DESCRIPTION
This is to avoid restarting the app to see the resulting color change, when changing the pure black setting.

It'll be good to call `finish()` on the settings activity, to avoid stacking activities every time the setting is changed.