### PR TITLE
Added archive and unarchive to the habit statistics page

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/ShowHabitMenu.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/ShowHabitMenu.kt
@@ -35,6 +35,9 @@ class ShowHabitMenu(
         if (preferences.isDeveloper) {
             menu.findItem(R.id.action_randomize).isVisible = true
         }
+        menu.findItem(R.id.action_archive_habit).isVisible = presenter.canArchive()
+        menu.findItem(R.id.action_unarchive_habit).isVisible = presenter.canUnarchive()
+
         return true
     }
 
@@ -42,6 +45,15 @@ class ShowHabitMenu(
         when (item.itemId) {
             R.id.action_edit_habit -> {
                 presenter.onEditHabit()
+                return true
+            }
+            R.id.action_archive_habit -> {
+                presenter.onArchiveHabits()
+                return true
+            }
+
+            R.id.action_unarchive_habit -> {
+                presenter.onUnarchiveHabits()
                 return true
             }
             R.id.action_delete -> {

--- a/uhabits-android/src/main/res/menu/show_habit.xml
+++ b/uhabits-android/src/main/res/menu/show_habit.xml
@@ -27,6 +27,16 @@
         app:showAsAction="never"/>
 
     <item
+        android:id="@+id/action_archive_habit"
+        android:title="@string/archive"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/action_unarchive_habit"
+        android:title="@string/unarchive"
+        app:showAsAction="never"/>
+
+    <item
         android:id="@+id/action_delete"
         android:title="@string/delete"
         app:showAsAction="never"/>

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/show/ShowHabitMenuPresenter.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/show/ShowHabitMenuPresenter.kt
@@ -19,6 +19,8 @@
 package org.isoron.uhabits.core.ui.screens.habits.show
 
 import org.isoron.uhabits.core.commands.CommandRunner
+import org.isoron.uhabits.core.commands.ArchiveHabitsCommand
+import org.isoron.uhabits.core.commands.UnarchiveHabitsCommand
 import org.isoron.uhabits.core.commands.DeleteHabitsCommand
 import org.isoron.uhabits.core.models.Entry
 import org.isoron.uhabits.core.models.Habit
@@ -40,8 +42,21 @@ class ShowHabitMenuPresenter(
     private val system: System,
     private val taskRunner: TaskRunner
 ) {
+
+    fun canArchive(): Boolean {
+        return !(habit.isArchived)
+    }
+
+    fun canUnarchive(): Boolean {
+        return habit.isArchived
+    }
+
     fun onEditHabit() {
         screen.showEditHabitScreen(habit)
+    }
+
+    fun onArchiveHabits() {
+        commandRunner.run(ArchiveHabitsCommand(habitList,listOf(habit)))
     }
 
     fun onExportCSV() {
@@ -62,6 +77,10 @@ class ShowHabitMenuPresenter(
             commandRunner.run(DeleteHabitsCommand(habitList, listOf(habit)))
             screen.close()
         }
+    }
+
+    fun onUnarchiveHabits() {
+        commandRunner.run(UnarchiveHabitsCommand(habitList,listOf(habit)))
     }
 
     fun onRandomize() {


### PR DESCRIPTION
Only one is visible at a time based on its current archive state. I did not run any of the tests, but I did check that it works.

* Only one option is available at a time and that option changes based on its archive state
* Archive does archive the habit, unarchive does unarchive the habit.

This implements #793 and #2191.

This is my first pull request ever.