### PR TITLE
Show habit question when entering record

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/CheckmarkDialog.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/CheckmarkDialog.kt
@@ -43,6 +43,24 @@ class CheckmarkDialog : AppCompatDialogFragment() {
         val prefs = appComponent.preferences
         val view = CheckmarkPopupBinding.inflate(LayoutInflater.from(context))
         val color = requireArguments().getInt("color")
+
+        // Get the habit ID and load description
+        val habitId = requireArguments().getLong("habitId", -1)
+        if (habitId != -1L) {
+            val habit = appComponent.habitList.getById(habitId)
+            habit?.let {
+                val description = it.question.trim()
+                if (description.isNotEmpty()) {
+                    view.habitDescription.text = description
+                    view.habitDescription.visibility = VISIBLE
+                } else {
+                    view.habitDescription.visibility = GONE
+                }
+            }
+        } else {
+            view.habitDescription.visibility = GONE
+        }
+
         arrayOf(view.yesBtn, view.skipBtn).forEach {
             it.setTextColor(color)
         }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/CheckmarkDialog.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/CheckmarkDialog.kt
@@ -53,6 +53,7 @@ class CheckmarkDialog : AppCompatDialogFragment() {
                 if (description.isNotEmpty()) {
                     view.habitDescription.text = description
                     view.habitDescription.visibility = VISIBLE
+                    view.habitDescription.setTextColor(color)
                 } else {
                     view.habitDescription.visibility = GONE
                 }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/NumberDialog.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/NumberDialog.kt
@@ -36,6 +36,24 @@ class NumberDialog : AppCompatDialogFragment() {
         val appComponent = (requireActivity().application as HabitsApplication).component
         val prefs = appComponent.preferences
         view = CheckmarkPopupBinding.inflate(LayoutInflater.from(context))
+
+        // Get the habit ID and load description
+        val habitId = requireArguments().getLong("habitId", -1)
+        if (habitId != -1L) {
+            val habit = appComponent.habitList.getById(habitId)
+            habit?.let {
+                val description = it.question.trim()
+                if (description.isNotEmpty()) {
+                    view.habitDescription.text = description
+                    view.habitDescription.visibility = View.VISIBLE
+                } else {
+                    view.habitDescription.visibility = View.GONE
+                }
+            }
+        } else {
+            view.habitDescription.visibility = View.GONE
+        }
+
         arrayOf(view.yesBtn).forEach {
             it.setTextColor(requireArguments().getInt("color"))
         }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/NumberDialog.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/NumberDialog.kt
@@ -36,6 +36,7 @@ class NumberDialog : AppCompatDialogFragment() {
         val appComponent = (requireActivity().application as HabitsApplication).component
         val prefs = appComponent.preferences
         view = CheckmarkPopupBinding.inflate(LayoutInflater.from(context))
+        val color = requireArguments().getInt("color")
 
         // Get the habit ID and load description
         val habitId = requireArguments().getLong("habitId", -1)
@@ -46,6 +47,7 @@ class NumberDialog : AppCompatDialogFragment() {
                 if (description.isNotEmpty()) {
                     view.habitDescription.text = description
                     view.habitDescription.visibility = View.VISIBLE
+                    view.habitDescription.setTextColor(color)
                 } else {
                     view.habitDescription.visibility = View.GONE
                 }
@@ -55,7 +57,7 @@ class NumberDialog : AppCompatDialogFragment() {
         }
 
         arrayOf(view.yesBtn).forEach {
-            it.setTextColor(requireArguments().getInt("color"))
+            it.setTextColor(color)
         }
         arrayOf(view.noBtn, view.unknownBtnNumber).forEach {
             it.setTextColor(view.root.sres.getColor(R.attr.contrast60))

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsScreen.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsScreen.kt
@@ -270,13 +270,15 @@ class ListHabitsScreen
     override fun showNumberPopup(
         value: Double,
         notes: String,
-        callback: ListHabitsBehavior.NumberPickerCallback
+        callback: ListHabitsBehavior.NumberPickerCallback,
+        habit: Habit?
     ) {
         val fm = (context as AppCompatActivity).supportFragmentManager
         val dialog = NumberDialog()
         dialog.arguments = Bundle().apply {
             putDouble("value", value)
             putString("notes", notes)
+            habit?.id?.let { putLong("habitId", it) }
         }
         dialog.onToggle = { v, n -> callback.onNumberPicked(v, n) }
         dialog.dismissCurrentAndShow(fm, "numberDialog")
@@ -286,7 +288,8 @@ class ListHabitsScreen
         selectedValue: Int,
         notes: String,
         color: PaletteColor,
-        callback: ListHabitsBehavior.CheckMarkDialogCallback
+        callback: ListHabitsBehavior.CheckMarkDialogCallback,
+        habit: Habit?
     ) {
         val theme = rootView.get().currentTheme()
         val fm = (context as AppCompatActivity).supportFragmentManager
@@ -295,6 +298,7 @@ class ListHabitsScreen
             putInt("color", theme.color(color).toInt())
             putInt("value", selectedValue)
             putString("notes", notes)
+            habit?.id?.let { putLong("habitId", it) }
         }
         dialog.onToggle = { v, n -> callback.onNotesSaved(v, n) }
         dialog.dismissCurrentAndShow(fm, "checkmarkDialog")

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsScreen.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsScreen.kt
@@ -273,9 +273,11 @@ class ListHabitsScreen
         callback: ListHabitsBehavior.NumberPickerCallback,
         habit: Habit?
     ) {
+        val theme = rootView.get().currentTheme()
         val fm = (context as AppCompatActivity).supportFragmentManager
         val dialog = NumberDialog()
         dialog.arguments = Bundle().apply {
+            habit?.color?.let { putInt("color", theme.color(it).toInt()) }
             putDouble("value", value)
             putString("notes", notes)
             habit?.id?.let { putLong("habitId", it) }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsScreen.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsScreen.kt
@@ -287,7 +287,6 @@ class ListHabitsScreen
     override fun showCheckmarkPopup(
         selectedValue: Int,
         notes: String,
-        color: PaletteColor,
         callback: ListHabitsBehavior.CheckMarkDialogCallback,
         habit: Habit?
     ) {
@@ -295,7 +294,7 @@ class ListHabitsScreen
         val fm = (context as AppCompatActivity).supportFragmentManager
         val dialog = CheckmarkDialog()
         dialog.arguments = Bundle().apply {
-            putInt("color", theme.color(color).toInt())
+            habit?.color?.let { putInt("color", theme.color(it).toInt()) }
             putInt("value", selectedValue)
             putString("notes", notes)
             habit?.id?.let { putLong("habitId", it) }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/ShowHabitActivity.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/ShowHabitActivity.kt
@@ -41,7 +41,6 @@ import org.isoron.uhabits.activities.common.dialogs.NumberDialog
 import org.isoron.uhabits.core.commands.Command
 import org.isoron.uhabits.core.commands.CommandRunner
 import org.isoron.uhabits.core.models.Habit
-import org.isoron.uhabits.core.models.PaletteColor
 import org.isoron.uhabits.core.preferences.Preferences
 import org.isoron.uhabits.core.ui.callbacks.OnConfirmedCallback
 import org.isoron.uhabits.core.ui.screens.habits.list.ListHabitsBehavior
@@ -190,14 +189,13 @@ class ShowHabitActivity : AppCompatActivity(), CommandRunner.Listener {
         override fun showCheckmarkPopup(
             selectedValue: Int,
             notes: String,
-            color: PaletteColor,
             callback: ListHabitsBehavior.CheckMarkDialogCallback,
             habit: Habit?
         ) {
             val theme = view.currentTheme()
             val dialog = CheckmarkDialog()
             dialog.arguments = Bundle().apply {
-                putInt("color", theme.color(color).toInt())
+                habit?.color?.let { putInt("color", theme.color(it).toInt()) }
                 putInt("value", selectedValue)
                 putString("notes", notes)
                 putLong("habitId", habit?.id ?: -1)

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/ShowHabitActivity.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/ShowHabitActivity.kt
@@ -176,8 +176,10 @@ class ShowHabitActivity : AppCompatActivity(), CommandRunner.Listener {
             callback: ListHabitsBehavior.NumberPickerCallback,
             habit: Habit?
         ) {
+            val theme = view.currentTheme()
             val dialog = NumberDialog()
             dialog.arguments = Bundle().apply {
+                habit?.color?.let { putInt("color", theme.color(it).toInt()) }
                 putDouble("value", value)
                 putString("notes", notes)
                 putLong("habitId", habit?.id ?: -1)

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/ShowHabitActivity.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/show/ShowHabitActivity.kt
@@ -174,12 +174,14 @@ class ShowHabitActivity : AppCompatActivity(), CommandRunner.Listener {
         override fun showNumberPopup(
             value: Double,
             notes: String,
-            callback: ListHabitsBehavior.NumberPickerCallback
+            callback: ListHabitsBehavior.NumberPickerCallback,
+            habit: Habit?
         ) {
             val dialog = NumberDialog()
             dialog.arguments = Bundle().apply {
                 putDouble("value", value)
                 putString("notes", notes)
+                putLong("habitId", habit?.id ?: -1)
             }
             dialog.onToggle = { v, n -> callback.onNumberPicked(v, n) }
             dialog.dismissCurrentAndShow(supportFragmentManager, "numberDialog")
@@ -189,7 +191,8 @@ class ShowHabitActivity : AppCompatActivity(), CommandRunner.Listener {
             selectedValue: Int,
             notes: String,
             color: PaletteColor,
-            callback: ListHabitsBehavior.CheckMarkDialogCallback
+            callback: ListHabitsBehavior.CheckMarkDialogCallback,
+            habit: Habit?
         ) {
             val theme = view.currentTheme()
             val dialog = CheckmarkDialog()
@@ -197,6 +200,7 @@ class ShowHabitActivity : AppCompatActivity(), CommandRunner.Listener {
                 putInt("color", theme.color(color).toInt())
                 putInt("value", selectedValue)
                 putString("notes", notes)
+                putLong("habitId", habit?.id ?: -1)
             }
             dialog.onToggle = { v, n -> callback.onNotesSaved(v, n) }
             dialog.dismissCurrentAndShow(supportFragmentManager, "checkmarkDialog")

--- a/uhabits-android/src/main/res/layout/checkmark_popup.xml
+++ b/uhabits-android/src/main/res/layout/checkmark_popup.xml
@@ -29,6 +29,17 @@
     android:orientation="vertical"
     app:divider="@drawable/checkmark_dialog_divider"
     app:showDividers="middle">
+    
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/habitDescription"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:background="@color/transparent"
+        android:gravity="center"
+        android:padding="4dp"
+        android:textStyle="italic"
+        android:textSize="@dimen/smallTextSize" />
 
     <androidx.appcompat.widget.AppCompatEditText
         android:id="@+id/notes"

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsBehavior.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsBehavior.kt
@@ -55,7 +55,7 @@ open class ListHabitsBehavior @Inject constructor(
         val entry = habit.computedEntries.get(timestamp!!)
         if (habit.type == HabitType.NUMERICAL) {
             val oldValue = entry.value.toDouble() / 1000
-            screen.showNumberPopup(oldValue, entry.notes) { newValue: Double, newNotes: String ->
+            screen.showNumberPopup(oldValue, entry.notes, { newValue: Double, newNotes: String ->
                 val value = (newValue * 1000).roundToInt()
                 if (newValue != oldValue) {
                     if (
@@ -66,16 +66,18 @@ open class ListHabitsBehavior @Inject constructor(
                     }
                 }
                 commandRunner.run(CreateRepetitionCommand(habitList, habit, timestamp, value, newNotes))
-            }
+            }, habit)
         } else {
             screen.showCheckmarkPopup(
                 entry.value,
                 entry.notes,
-                habit.color
-            ) { newValue: Int, newNotes: String ->
-                if (newValue != entry.value && newValue == YES_MANUAL) screen.showConfetti(habit.color, x, y)
-                commandRunner.run(CreateRepetitionCommand(habitList, habit, timestamp, newValue, newNotes))
-            }
+                habit.color,
+                { newValue: Int, newNotes: String ->
+                    if (newValue != entry.value && newValue == YES_MANUAL) screen.showConfetti(habit.color, x, y)
+                    commandRunner.run(CreateRepetitionCommand(habitList, habit, timestamp, newValue, newNotes))
+                },
+                habit
+            )
         }
     }
 
@@ -179,13 +181,15 @@ open class ListHabitsBehavior @Inject constructor(
         fun showNumberPopup(
             value: Double,
             notes: String,
-            callback: NumberPickerCallback
+            callback: NumberPickerCallback,
+            habit: Habit? = null
         )
         fun showCheckmarkPopup(
             selectedValue: Int,
             notes: String,
             color: PaletteColor,
-            callback: CheckMarkDialogCallback
+            callback: CheckMarkDialogCallback,
+            habit: Habit? = null
         )
         fun showSendBugReportToDeveloperScreen(log: String)
         fun showSendFileScreen(filename: String)

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsBehavior.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsBehavior.kt
@@ -71,7 +71,6 @@ open class ListHabitsBehavior @Inject constructor(
             screen.showCheckmarkPopup(
                 entry.value,
                 entry.notes,
-                habit.color,
                 { newValue: Int, newNotes: String ->
                     if (newValue != entry.value && newValue == YES_MANUAL) screen.showConfetti(habit.color, x, y)
                     commandRunner.run(CreateRepetitionCommand(habitList, habit, timestamp, newValue, newNotes))
@@ -187,7 +186,6 @@ open class ListHabitsBehavior @Inject constructor(
         fun showCheckmarkPopup(
             selectedValue: Int,
             notes: String,
-            color: PaletteColor,
             callback: CheckMarkDialogCallback,
             habit: Habit? = null
         )

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/show/views/HistoryCard.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/show/views/HistoryCard.kt
@@ -97,18 +97,20 @@ class HistoryCardPresenter(
         screen.showCheckmarkPopup(
             entry.value,
             entry.notes,
-            habit.color
-        ) { newValue, newNotes ->
-            commandRunner.run(
-                CreateRepetitionCommand(
-                    habitList,
-                    habit,
-                    timestamp,
-                    newValue,
-                    newNotes
+            habit.color,
+            { newValue, newNotes ->
+                commandRunner.run(
+                    CreateRepetitionCommand(
+                        habitList,
+                        habit,
+                        timestamp,
+                        newValue,
+                        newNotes
+                    )
                 )
-            )
-        }
+            },
+            habit
+        )
     }
 
     private fun toggle(timestamp: Timestamp) {
@@ -134,19 +136,21 @@ class HistoryCardPresenter(
         val oldValue = entry.value
         screen.showNumberPopup(
             value = oldValue / 1000.0,
-            notes = entry.notes
-        ) { newValue: Double, newNotes: String ->
-            val thousands = (newValue * 1000).roundToInt()
-            commandRunner.run(
-                CreateRepetitionCommand(
-                    habitList,
-                    habit,
-                    timestamp,
-                    thousands,
-                    newNotes
+            notes = entry.notes,
+            { newValue: Double, newNotes: String ->
+                val thousands = (newValue * 1000).roundToInt()
+                commandRunner.run(
+                    CreateRepetitionCommand(
+                        habitList,
+                        habit,
+                        timestamp,
+                        thousands,
+                        newNotes
+                    )
                 )
-            )
-        }
+            },
+            habit
+        )
     }
 
     fun onClickEditButton() {
@@ -207,13 +211,15 @@ class HistoryCardPresenter(
         fun showNumberPopup(
             value: Double,
             notes: String,
-            callback: ListHabitsBehavior.NumberPickerCallback
+            callback: ListHabitsBehavior.NumberPickerCallback,
+            habit: Habit? = null
         )
         fun showCheckmarkPopup(
             selectedValue: Int,
             notes: String,
             color: PaletteColor,
-            callback: ListHabitsBehavior.CheckMarkDialogCallback
+            callback: ListHabitsBehavior.CheckMarkDialogCallback,
+            habit: Habit? = null
         )
     }
 }

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/show/views/HistoryCard.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/show/views/HistoryCard.kt
@@ -97,7 +97,6 @@ class HistoryCardPresenter(
         screen.showCheckmarkPopup(
             entry.value,
             entry.notes,
-            habit.color,
             { newValue, newNotes ->
                 commandRunner.run(
                     CreateRepetitionCommand(
@@ -217,7 +216,6 @@ class HistoryCardPresenter(
         fun showCheckmarkPopup(
             selectedValue: Int,
             notes: String,
-            color: PaletteColor,
             callback: ListHabitsBehavior.CheckMarkDialogCallback,
             habit: Habit? = null
         )

--- a/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsBehaviorTest.kt
+++ b/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsBehaviorTest.kt
@@ -82,7 +82,8 @@ class ListHabitsBehaviorTest : BaseUnitTest() {
         verify(screen).showNumberPopup(
             eq(0.1),
             eq(""),
-            picker.capture()
+            picker.capture(),
+            eq(habit2)
         )
         picker.lastValue.onNumberPicked(100.0, "")
         val today = getTodayWithOffset()


### PR DESCRIPTION
For each habit, we are already allowed to write a question about it. We currently only see this question when looking at the overview page for the habit, but as a user, I would also like to see it on the pop-up when entering the daily record, so that I can add additional details to consider. If there is no question saved the pop-up will look the same as now. Not sure if others would also like this change though, so I could make this configurable if preferred.