### PR TITLE
Reverse order of noBtn and yesBtn

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/CheckmarkDialog.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/dialogs/CheckmarkDialog.kt
@@ -25,6 +25,7 @@ import android.view.LayoutInflater
 import android.view.View.GONE
 import android.view.View.VISIBLE
 import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.preference.PreferenceManager
 import org.isoron.uhabits.HabitsApplication
 import org.isoron.uhabits.R
 import org.isoron.uhabits.core.models.Entry.Companion.NO
@@ -53,8 +54,12 @@ class CheckmarkDialog : AppCompatDialogFragment() {
             it.typeface = getFontAwesome(requireContext())
         }
         view.notes.setText(requireArguments().getString("notes")!!)
-        if (!prefs.isSkipEnabled) view.skipBtn.visibility = GONE
-        if (!prefs.areQuestionMarksEnabled) view.unknownBtn.visibility = GONE
+        if (!prefs.isSkipEnabled)
+            view.skipBtn.visibility = GONE
+
+        if (!prefs.areQuestionMarksEnabled)
+            view.unknownBtn.visibility = GONE
+
         view.booleanButtons.visibility = VISIBLE
         val dialog = Dialog(requireContext())
         dialog.setContentView(view.root)

--- a/uhabits-android/src/main/res/layout/checkmark_popup.xml
+++ b/uhabits-android/src/main/res/layout/checkmark_popup.xml
@@ -53,9 +53,9 @@
         app:showDividers="middle">
 
         <TextView
-            android:id="@+id/yesBtn"
+            android:id="@+id/noBtn"
             style="@style/CheckmarkPopupBtn"
-            android:text="@string/fa_check" />
+            android:text="@string/fa_times" />
 
         <TextView
             android:id="@+id/skipBtn"
@@ -63,9 +63,9 @@
             android:text="@string/fa_skipped" />
 
         <TextView
-            android:id="@+id/noBtn"
+            android:id="@+id/yesBtn"
             style="@style/CheckmarkPopupBtn"
-            android:text="@string/fa_times" />
+            android:text="@string/fa_check" />
 
         <TextView
             android:id="@+id/unknownBtn"

--- a/uhabits-android/src/main/res/values/strings.xml
+++ b/uhabits-android/src/main/res/values/strings.xml
@@ -147,6 +147,8 @@
     <string name="interface_preferences">Interface</string>
     <string name="reverse_days">Reverse order of days</string>
     <string name="reverse_days_description">Show days in reverse order on the main screen.</string>
+    <string name="reverse_cancel_confirm_action">Reverse cancel / confirm action</string>
+    <string name="reverse_cancel_confirm_action_description">Reverse order of buttons when confirming or cancelling entry on a habit.</string>
     <string name="day">Day</string>
     <string name="week">Week</string>
     <string name="month">Month</string>

--- a/uhabits-android/src/main/res/xml/preferences.xml
+++ b/uhabits-android/src/main/res/xml/preferences.xml
@@ -61,6 +61,14 @@
 
 
         <SwitchPreferenceCompat
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="false"
+            android:key="pref_checkmark_reverse_cancel_confirm"
+            android:summary="@string/reverse_cancel_confirm_action_description"
+            android:title="@string/reverse_cancel_confirm_action"
+            app:iconSpaceReserved="false" />
+        <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:key="pref_pure_black"
                 android:summary="@string/pure_black_description"


### PR DESCRIPTION
When confirming a habit for the day the order of noBtn and yesBtn are in reverse. Adjusted the default view to conform with universal UI/UX standards and added a preference in the settings to flip the buttons back to the old view if people still want to use the old style.

Tested briefly in android studio myself to confirm functionality, hope this can get merged and pushed to your new update :) Thank you for the work you've done on this app!

https://github.com/user-attachments/assets/05fcba76-ed6e-4867-823d-357101fa291a
