### PR TITLE
Fix #2210: Fix undoing the checkmark bug.

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/NumberButtonView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/NumberButtonView.kt
@@ -173,8 +173,7 @@ class NumberButtonView(
 
         fun draw(canvas: Canvas) {
             val activeColor = when {
-                value < 0.0 -> lowContrast
-                (targetType == AT_LEAST) && ((value == 0.0) && (threshold != 0.0)) -> lowContrast
+                (value < 0.0) || ((targetType == AT_LEAST) && ((value == 0.0) && (threshold != 0.0))) -> lowContrast
                 (targetType == AT_LEAST) && (value >= threshold) -> color
                 (targetType == AT_MOST) && (value <= threshold) -> color
                 else -> mediumContrast

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/NumberButtonView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/NumberButtonView.kt
@@ -174,11 +174,11 @@ class NumberButtonView(
         fun draw(canvas: Canvas) {
             val activeColor = when {
                 value < 0.0 -> lowContrast
+                (targetType == AT_LEAST) && ((value == 0.0) && (threshold != 0.0)) -> lowContrast
                 (targetType == AT_LEAST) && (value >= threshold) -> color
                 (targetType == AT_MOST) && (value <= threshold) -> color
                 else -> mediumContrast
             }
-
             val label: String
             val typeface: Typeface
             val textSize: Float

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/show/views/HistoryCard.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/show/views/HistoryCard.kt
@@ -46,6 +46,7 @@ import org.isoron.uhabits.core.ui.views.Theme
 import org.isoron.uhabits.core.utils.DateUtils
 import kotlin.math.roundToInt
 
+
 data class HistoryCardState(
     val color: PaletteColor,
     val firstWeekday: DayOfWeek,
@@ -165,7 +166,7 @@ class HistoryCardPresenter(
             val series = if (habit.isNumerical) {
                 entries.map {
                     when {
-                        it.value == Entry.UNKNOWN -> OFF
+                        (it.value == Entry.UNKNOWN) || ((habit.targetType == AT_LEAST) && (it.value == 0 && habit.targetValue != 0.0)) -> OFF
                         it.value == SKIP -> HATCHED
                         (habit.targetType == AT_MOST) && (it.value / 1000.0 <= habit.targetValue) -> ON
                         (habit.targetType == AT_LEAST) && (it.value / 1000.0 >= habit.targetValue) -> ON


### PR DESCRIPTION
Previously, when a user saved 0 for a measurable habit, the habit was incorrectly highlighted as completed, regardless of the actual target value. For example, a habit with a target of 10 would show as completed even when the user saved 0. This PR fixes the completion logic to only highlight habits when the saved value actually meets or exceeds the target value on both the Habits lists page and the Read page.