### PR TITLE
Feat: Add history average mode with include/exclude empty days option

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/edit/EditHabitActivity.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/edit/EditHabitActivity.kt
@@ -47,6 +47,7 @@ import org.isoron.uhabits.core.commands.EditHabitCommand
 import org.isoron.uhabits.core.models.Frequency
 import org.isoron.uhabits.core.models.Habit
 import org.isoron.uhabits.core.models.HabitType
+import org.isoron.uhabits.core.models.NumericalEmptyDaysMode
 import org.isoron.uhabits.core.models.NumericalHabitType
 import org.isoron.uhabits.core.models.NumericalHistoryType
 import org.isoron.uhabits.core.models.PaletteColor
@@ -86,6 +87,7 @@ class EditHabitActivity : AppCompatActivity() {
     var reminderMin = -1
     var reminderDays: WeekdayList = WeekdayList.EVERY_DAY
     var historyType = NumericalHistoryType.TOTAL
+    var emptyDaysMode = NumericalEmptyDaysMode.EXCLUDE_EMPTY
     var targetType = NumericalHabitType.AT_LEAST
 
     override fun onCreate(state: Bundle?) {
@@ -109,6 +111,7 @@ class EditHabitActivity : AppCompatActivity() {
             freqNum = habit.frequency.numerator
             freqDen = habit.frequency.denominator
             historyType = habit.historyType
+            emptyDaysMode = habit.emptyDaysMode
             targetType = habit.targetType
             habit.reminder?.let {
                 reminderHour = it.hour
@@ -189,6 +192,24 @@ class EditHabitActivity : AppCompatActivity() {
                     else -> NumericalHistoryType.AVERAGE
                 }
                 populateHistoryType()
+                dialog.dismiss()
+            }
+            val dialog = builder.create()
+            dialog.dismissCurrentAndShow()
+        }
+
+        populateIncludeEmptyDays()
+        binding.includeEmptyDaysPicker.setOnClickListener {
+            val builder = AlertDialog.Builder(this)
+            val arrayAdapter = ArrayAdapter<String>(this, android.R.layout.select_dialog_item)
+            arrayAdapter.add(getString(R.string.yes))
+            arrayAdapter.add(getString(R.string.no))
+            builder.setAdapter(arrayAdapter) { dialog, which ->
+                emptyDaysMode = when (which) {
+                    0 -> NumericalEmptyDaysMode.INCLUDE_EMPTY
+                    else -> NumericalEmptyDaysMode.EXCLUDE_EMPTY
+                }
+                populateIncludeEmptyDays()
                 dialog.dismiss()
             }
             val dialog = builder.create()
@@ -308,6 +329,7 @@ class EditHabitActivity : AppCompatActivity() {
             habit.unit = binding.unitInput.text.trim().toString()
         }
         habit.type = habitType
+        habit.emptyDaysMode = emptyDaysMode
 
         val command = if (habitId >= 0) {
             EditHabitCommand(
@@ -370,6 +392,13 @@ class EditHabitActivity : AppCompatActivity() {
         binding.historyTypePicker.text = when (historyType) {
             NumericalHistoryType.TOTAL -> getString(R.string.total)
             else -> getString(R.string.average)
+        }
+    }
+
+    private fun populateIncludeEmptyDays() {
+        binding.includeEmptyDaysPicker.text = when (emptyDaysMode) {
+            NumericalEmptyDaysMode.EXCLUDE_EMPTY -> getString(R.string.no)
+            else -> getString(R.string.yes)
         }
     }
     private fun populateTargetType() {

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/edit/EditHabitActivity.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/edit/EditHabitActivity.kt
@@ -48,6 +48,7 @@ import org.isoron.uhabits.core.models.Frequency
 import org.isoron.uhabits.core.models.Habit
 import org.isoron.uhabits.core.models.HabitType
 import org.isoron.uhabits.core.models.NumericalHabitType
+import org.isoron.uhabits.core.models.NumericalHistoryType
 import org.isoron.uhabits.core.models.PaletteColor
 import org.isoron.uhabits.core.models.Reminder
 import org.isoron.uhabits.core.models.WeekdayList
@@ -84,6 +85,7 @@ class EditHabitActivity : AppCompatActivity() {
     var reminderHour = -1
     var reminderMin = -1
     var reminderDays: WeekdayList = WeekdayList.EVERY_DAY
+    var historyType = NumericalHistoryType.TOTAL
     var targetType = NumericalHabitType.AT_LEAST
 
     override fun onCreate(state: Bundle?) {
@@ -106,6 +108,7 @@ class EditHabitActivity : AppCompatActivity() {
             color = habit.color
             freqNum = habit.frequency.numerator
             freqDen = habit.frequency.denominator
+            historyType = habit.historyType
             targetType = habit.targetType
             habit.reminder?.let {
                 reminderHour = it.hour
@@ -137,6 +140,7 @@ class EditHabitActivity : AppCompatActivity() {
         when (habitType) {
             HabitType.YES_NO -> {
                 binding.unitOuterBox.visibility = View.GONE
+                binding.historyTypeOuterBox.visibility = View.GONE
                 binding.targetOuterBox.visibility = View.GONE
                 binding.targetTypeOuterBox.visibility = View.GONE
             }
@@ -171,6 +175,24 @@ class EditHabitActivity : AppCompatActivity() {
                 populateFrequency()
             }
             picker.dismissCurrentAndShow(supportFragmentManager, "frequencyPicker")
+        }
+
+        populateHistoryType()
+        binding.historyTypePicker.setOnClickListener {
+            val builder = AlertDialog.Builder(this)
+            val arrayAdapter = ArrayAdapter<String>(this, android.R.layout.select_dialog_item)
+            arrayAdapter.add(getString(R.string.total))
+            arrayAdapter.add(getString(R.string.average))
+            builder.setAdapter(arrayAdapter) { dialog, which ->
+                historyType = when (which) {
+                    0 -> NumericalHistoryType.TOTAL
+                    else -> NumericalHistoryType.AVERAGE
+                }
+                populateHistoryType()
+                dialog.dismiss()
+            }
+            val dialog = builder.create()
+            dialog.dismissCurrentAndShow()
         }
 
         populateTargetType()
@@ -281,6 +303,7 @@ class EditHabitActivity : AppCompatActivity() {
         habit.frequency = Frequency(freqNum, freqDen)
         if (habitType == HabitType.NUMERICAL) {
             habit.targetValue = binding.targetInput.text.toString().toDouble()
+            habit.historyType = historyType
             habit.targetType = targetType
             habit.unit = binding.unitInput.text.trim().toString()
         }
@@ -343,6 +366,12 @@ class EditHabitActivity : AppCompatActivity() {
         }
     }
 
+    private fun populateHistoryType() {
+        binding.historyTypePicker.text = when (historyType) {
+            NumericalHistoryType.TOTAL -> getString(R.string.total)
+            else -> getString(R.string.average)
+        }
+    }
     private fun populateTargetType() {
         binding.targetTypePicker.text = when (targetType) {
             NumericalHabitType.AT_MOST -> getString(R.string.target_type_at_most)

--- a/uhabits-android/src/main/res/layout/activity_edit_habit.xml
+++ b/uhabits-android/src/main/res/layout/activity_edit_habit.xml
@@ -172,19 +172,58 @@
             </FrameLayout>
 
             <!-- History Type -->
-            <FrameLayout
+            <LinearLayout
                 android:id="@+id/historyTypeOuterBox"
-                style="@style/FormOuterBox">
-                <LinearLayout style="@style/FormInnerBox">
-                    <TextView
-                        style="@style/FormLabel"
-                        android:text="@string/history_type" />
-                    <TextView
-                        style="@style/FormDropdown"
-                        android:id="@+id/historyTypePicker"
-                        android:text="@string/total" />
-                </LinearLayout>
-            </FrameLayout>
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:baselineAligned="false">
+                <FrameLayout
+                    style="@style/FormOuterBox"
+                    android:layout_width="0dp"
+                    android:layout_weight="1">
+                    <LinearLayout style="@style/FormInnerBox">
+                        <TextView
+                            style="@style/FormLabel"
+                            android:text="@string/history_type" />
+                        <TextView
+                            style="@style/FormDropdown"
+                            android:id="@+id/historyTypePicker"
+                            android:text="@string/total"
+                            android:textColor="?attr/contrast100"
+                            />
+                    </LinearLayout>
+                </FrameLayout>
+                <FrameLayout
+                    style="@style/FormOuterBox"
+                    android:layout_width="0dp"
+                    android:layout_weight="1">
+                    <LinearLayout style="@style/FormInnerBox">
+                        <TextView
+                            style="@style/FormLabel"
+                            android:text="@string/include_empty_days" />
+                        <TextView
+                            style="@style/FormDropdown"
+                            android:id="@+id/includeEmptyDaysPicker"
+                            android:text="@string/no"
+                            android:textColor="?attr/contrast100"
+                            />
+                    </LinearLayout>
+                </FrameLayout>
+            </LinearLayout>
+<!--            <FrameLayout-->
+<!--                android:id="@+id/historyTypeOuterBox"-->
+<!--                style="@style/FormOuterBox">-->
+<!--                <LinearLayout style="@style/FormInnerBox">-->
+<!--                    <TextView-->
+<!--                        style="@style/FormLabel"-->
+<!--                        android:text="@string/history_type" />-->
+<!--                    <TextView-->
+<!--                        style="@style/FormDropdown"-->
+<!--                        android:id="@+id/historyTypePicker"-->
+<!--                        android:text="@string/total" />-->
+<!--                </LinearLayout>-->
+<!--            </FrameLayout>-->
 
             <LinearLayout
                 android:id="@+id/targetOuterBox"

--- a/uhabits-android/src/main/res/layout/activity_edit_habit.xml
+++ b/uhabits-android/src/main/res/layout/activity_edit_habit.xml
@@ -171,6 +171,21 @@
                 </LinearLayout>
             </FrameLayout>
 
+            <!-- History Type -->
+            <FrameLayout
+                android:id="@+id/historyTypeOuterBox"
+                style="@style/FormOuterBox">
+                <LinearLayout style="@style/FormInnerBox">
+                    <TextView
+                        style="@style/FormLabel"
+                        android:text="@string/history_type" />
+                    <TextView
+                        style="@style/FormDropdown"
+                        android:id="@+id/historyTypePicker"
+                        android:text="@string/total" />
+                </LinearLayout>
+            </FrameLayout>
+
             <LinearLayout
                 android:id="@+id/targetOuterBox"
                 android:layout_width="match_parent"

--- a/uhabits-android/src/main/res/values/strings.xml
+++ b/uhabits-android/src/main/res/values/strings.xml
@@ -185,6 +185,7 @@
     <string name="calendar">Calendar</string>
     <string name="unit">Unit</string>
     <string name="history_type">History Type</string>
+    <string name="include_empty_days">Include empty days</string>
     <string name="target_type">Target Type</string>
     <string name="target_type_at_least">At least</string>
     <string name="target_type_at_most">At most</string>

--- a/uhabits-android/src/main/res/values/strings.xml
+++ b/uhabits-android/src/main/res/values/strings.xml
@@ -184,12 +184,14 @@
     <string name="value">Value</string>
     <string name="calendar">Calendar</string>
     <string name="unit">Unit</string>
+    <string name="history_type">History Type</string>
     <string name="target_type">Target Type</string>
     <string name="target_type_at_least">At least</string>
     <string name="target_type_at_most">At most</string>
     <string name="example_question_boolean">e.g. Did you exercise today?</string>
     <string name="question">Question</string>
     <string name="target">Target</string>
+    <string name="average">Average</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="customize_notification_summary">Change sound, vibration, light and other notification settings</string>

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/EntryList.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/EntryList.kt
@@ -338,33 +338,33 @@ fun List<Entry>.groupedSum(
 fun List<Entry>.groupedAverage(
     truncateField: DateUtils.TruncateField,
     firstWeekday: Int = Calendar.SATURDAY,
-    isNumerical: Boolean
+    isNumerical: Boolean,
+    emptyDaysMode: NumericalEmptyDaysMode
 ): List<Entry> =
     this
         .map { (timestamp, value) ->
             if (isNumerical) {
                 if (value == SKIP) Entry(timestamp, 0)
-                else Entry(timestamp, max(0, value))
+                else Entry(timestamp, max(0, value)) // UNKNOWN/negatives -> 0
             } else {
                 Entry(timestamp, if (value == YES_MANUAL) 1000 else 0)
             }
         }
         .groupBy { entry ->
-            when (truncateField) {
-                DateUtils.TruncateField.WEEK_NUMBER ->
-                    entry.timestamp.truncate(truncateField, firstWeekday)
-                else ->
-                    entry.timestamp.truncate(truncateField, firstWeekday)
-            }
+            entry.timestamp.truncate(truncateField, firstWeekday)
         }
         .entries.map { (timestamp, entries) ->
-            val nonEmpty = entries.filter { it.value > 0}
-            val avg = if (nonEmpty.isEmpty()) 0
-            else nonEmpty.map { it.value }.average().roundToInt()
+            val values = when (emptyDaysMode) {
+                NumericalEmptyDaysMode.INCLUDE_EMPTY ->
+                    entries.map { it.value }
+                NumericalEmptyDaysMode.EXCLUDE_EMPTY ->
+                    entries.map { it.value }.filter { it > 0 }
+            }
+            val avg = if (values.isEmpty()) 0 else values.average().roundToInt()
             Entry(timestamp, avg)
         }
-        // 4) Sort buckets (latest first)
         .sortedByDescending { (timestamp, _) -> timestamp.unixTime }
+
 
 /**
  * Counts the number of days with vaLue SKIP in the given period.

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/EntryList.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/EntryList.kt
@@ -30,6 +30,7 @@ import javax.annotation.concurrent.ThreadSafe
 import kotlin.collections.set
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.roundToInt
 
 @ThreadSafe
 open class EntryList {
@@ -317,6 +318,53 @@ fun List<Entry>.groupedSum(
         -timestamp.unixTime
     }
 }
+
+/**
+ * Given a list of entries, truncates the timestamp of each entry (according to the field given),
+ * groups the entries according to this truncated timestamp, then creates a new entry (t,v) for
+ * each group, where t is the truncated timestamp and v is the average of the values of all
+ * non-empty entries in the group.
+ *
+ * For numerical habits, non-positive entry values are ignored when computing the average. For
+ * boolean habits, each YES_MANUAL value is converted to 1000 and all other values are converted
+ * to zero before averaging.
+ *
+ * The returned list is sorted by timestamp, with the newest entry coming first and the oldest
+ * entry coming last. If the original list has gaps in it (for example, weeks or months without
+ * any entries), then the list produced by this method will also have gaps.
+ *
+ * The argument [firstWeekday] is only relevant when truncating by week.
+ */
+fun List<Entry>.groupedAverage(
+    truncateField: DateUtils.TruncateField,
+    firstWeekday: Int = Calendar.SATURDAY,
+    isNumerical: Boolean
+): List<Entry> =
+    this
+        .map { (timestamp, value) ->
+            if (isNumerical) {
+                if (value == SKIP) Entry(timestamp, 0)
+                else Entry(timestamp, max(0, value))
+            } else {
+                Entry(timestamp, if (value == YES_MANUAL) 1000 else 0)
+            }
+        }
+        .groupBy { entry ->
+            when (truncateField) {
+                DateUtils.TruncateField.WEEK_NUMBER ->
+                    entry.timestamp.truncate(truncateField, firstWeekday)
+                else ->
+                    entry.timestamp.truncate(truncateField, firstWeekday)
+            }
+        }
+        .entries.map { (timestamp, entries) ->
+            val nonEmpty = entries.filter { it.value > 0}
+            val avg = if (nonEmpty.isEmpty()) 0
+            else nonEmpty.map { it.value }.average().roundToInt()
+            Entry(timestamp, avg)
+        }
+        // 4) Sort buckets (latest first)
+        .sortedByDescending { (timestamp, _) -> timestamp.unixTime }
 
 /**
  * Counts the number of days with vaLue SKIP in the given period.

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/Habit.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/Habit.kt
@@ -32,6 +32,7 @@ data class Habit(
     var question: String = "",
     var reminder: Reminder? = null,
     var historyType: NumericalHistoryType = NumericalHistoryType.TOTAL,
+    var emptyDaysMode: NumericalEmptyDaysMode = NumericalEmptyDaysMode.EXCLUDE_EMPTY,
     var targetType: NumericalHabitType = NumericalHabitType.AT_LEAST,
     var targetValue: Double = 0.0,
     var type: HabitType = HabitType.YES_NO,
@@ -119,6 +120,7 @@ data class Habit(
         this.question = other.question
         this.reminder = other.reminder
         this.historyType = other.historyType
+        this.emptyDaysMode = other.emptyDaysMode
         this.targetType = other.targetType
         this.targetValue = other.targetValue
         this.type = other.type
@@ -140,6 +142,7 @@ data class Habit(
         if (question != other.question) return false
         if (reminder != other.reminder) return false
         if (historyType != other.historyType) return false
+        if (emptyDaysMode != other.emptyDaysMode) return false
         if (targetType != other.targetType) return false
         if (targetValue != other.targetValue) return false
         if (type != other.type) return false
@@ -160,6 +163,7 @@ data class Habit(
         result = 31 * result + question.hashCode()
         result = 31 * result + (reminder?.hashCode() ?: 0)
         result = 31 * result + historyType.value
+        result = 31 * result + emptyDaysMode.value
         result = 31 * result + targetType.value
         result = 31 * result + targetValue.hashCode()
         result = 31 * result + type.value

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/Habit.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/Habit.kt
@@ -31,6 +31,7 @@ data class Habit(
     var position: Int = 0,
     var question: String = "",
     var reminder: Reminder? = null,
+    var historyType: NumericalHistoryType = NumericalHistoryType.TOTAL,
     var targetType: NumericalHabitType = NumericalHabitType.AT_LEAST,
     var targetValue: Double = 0.0,
     var type: HabitType = HabitType.YES_NO,
@@ -117,6 +118,7 @@ data class Habit(
         this.position = other.position
         this.question = other.question
         this.reminder = other.reminder
+        this.historyType = other.historyType
         this.targetType = other.targetType
         this.targetValue = other.targetValue
         this.type = other.type
@@ -137,6 +139,7 @@ data class Habit(
         if (position != other.position) return false
         if (question != other.question) return false
         if (reminder != other.reminder) return false
+        if (historyType != other.historyType) return false
         if (targetType != other.targetType) return false
         if (targetValue != other.targetValue) return false
         if (type != other.type) return false
@@ -156,6 +159,7 @@ data class Habit(
         result = 31 * result + position
         result = 31 * result + question.hashCode()
         result = 31 * result + (reminder?.hashCode() ?: 0)
+        result = 31 * result + historyType.value
         result = 31 * result + targetType.value
         result = 31 * result + targetValue.hashCode()
         result = 31 * result + type.value

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/NumericalEmptyDaysMode.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/NumericalEmptyDaysMode.kt
@@ -1,0 +1,17 @@
+package org.isoron.uhabits.core.models
+
+import java.lang.IllegalStateException
+
+enum class NumericalEmptyDaysMode(val value: Int) {
+    EXCLUDE_EMPTY(0), INCLUDE_EMPTY(1);
+
+    companion object {
+        fun fromInt(value: Int): NumericalEmptyDaysMode {
+            return when (value) {
+                EXCLUDE_EMPTY.value -> EXCLUDE_EMPTY
+                INCLUDE_EMPTY.value -> INCLUDE_EMPTY
+                else -> throw IllegalStateException()
+            }
+        }
+    }
+}

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/NumericalHistoryType.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/NumericalHistoryType.kt
@@ -1,0 +1,17 @@
+package org.isoron.uhabits.core.models
+
+import java.lang.IllegalStateException
+
+enum class NumericalHistoryType(val value: Int) {
+    TOTAL(0), AVERAGE(1);
+
+    companion object {
+        fun fromInt(value: Int): NumericalHistoryType {
+            return when (value) {
+                TOTAL.value -> TOTAL
+                AVERAGE.value -> AVERAGE
+                else -> throw IllegalStateException()
+            }
+        }
+    }
+}

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/show/views/BarCard.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/show/views/BarCard.kt
@@ -23,6 +23,8 @@ import org.isoron.uhabits.core.models.Entry
 import org.isoron.uhabits.core.models.Habit
 import org.isoron.uhabits.core.models.PaletteColor
 import org.isoron.uhabits.core.models.groupedSum
+import org.isoron.uhabits.core.models.groupedAverage
+import org.isoron.uhabits.core.models.NumericalHistoryType
 import org.isoron.uhabits.core.preferences.Preferences
 import org.isoron.uhabits.core.ui.views.Theme
 import org.isoron.uhabits.core.utils.DateUtils
@@ -59,11 +61,18 @@ class BarCardPresenter(
             }
             val today = DateUtils.getTodayWithOffset()
             val oldest = habit.computedEntries.getKnown().lastOrNull()?.timestamp ?: today
-            val entries = habit.computedEntries.getByInterval(oldest, today).groupedSum(
-                truncateField = ScoreCardPresenter.getTruncateField(bucketSize),
-                firstWeekday = firstWeekday,
-                isNumerical = habit.isNumerical
-            )
+            val entries = when (habit.historyType) {
+                NumericalHistoryType.TOTAL -> habit.computedEntries.getByInterval(oldest, today).groupedSum(
+                    truncateField = ScoreCardPresenter.getTruncateField(bucketSize),
+                    firstWeekday = firstWeekday,
+                    isNumerical = habit.isNumerical
+                )
+                NumericalHistoryType.AVERAGE -> habit.computedEntries.getByInterval(oldest, today).groupedAverage(
+                    truncateField = ScoreCardPresenter.getTruncateField(bucketSize),
+                    firstWeekday = firstWeekday,
+                    isNumerical = habit.isNumerical
+                )
+            }
             return BarCardState(
                 theme = theme,
                 entries = entries,

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/show/views/BarCard.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/show/views/BarCard.kt
@@ -70,7 +70,8 @@ class BarCardPresenter(
                 NumericalHistoryType.AVERAGE -> habit.computedEntries.getByInterval(oldest, today).groupedAverage(
                     truncateField = ScoreCardPresenter.getTruncateField(bucketSize),
                     firstWeekday = firstWeekday,
-                    isNumerical = habit.isNumerical
+                    isNumerical = habit.isNumerical,
+                    emptyDaysMode = habit.emptyDaysMode
                 )
             }
             return BarCardState(


### PR DESCRIPTION
### Summary
This PR introduces new functionality for numerical habits, allowing users to
view averages inside the history card. Additionally, users can choose
whether empty days (zeros) are included or excluded from average calculations.

### Motivation
This feature addresses [#1299](https://github.com/iSoron/uhabits/discussions/1299),
providing more flexible and meaningful statistics for numerical habits.
Users can now:
- Compare average values across calendar weeks/months/years
- Decide whether missing days should dilute the average or not

### Screenshots
<img width="411" height="907" alt="image" src="https://github.com/user-attachments/assets/8a1c3358-c6a7-4e0f-a193-83ef15ab1650" />

<img width="404" height="900" alt="image" src="https://github.com/user-attachments/assets/73f5dbcb-03de-49ca-b3c3-9fbe47ed49ff" />
