### PR TITLE
Settings-Fix-UI: Improve ripple effect on pure-dark mode and process navigation bar insets on Settings screen

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/settings/SettingsActivity.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/settings/SettingsActivity.kt
@@ -26,7 +26,6 @@ import org.isoron.uhabits.R
 import org.isoron.uhabits.activities.AndroidThemeSwitcher
 import org.isoron.uhabits.core.models.PaletteColor
 import org.isoron.uhabits.databinding.SettingsActivityBinding
-import org.isoron.uhabits.utils.applyBottomInset
 import org.isoron.uhabits.utils.applyRootViewInsets
 import org.isoron.uhabits.utils.setupToolbar
 
@@ -45,7 +44,6 @@ class SettingsActivity : AppCompatActivity() {
             theme = themeSwitcher.currentTheme
         )
         binding.root.applyRootViewInsets()
-        binding.root.applyBottomInset()
         setContentView(binding.root)
     }
 }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/settings/SettingsFragment.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/settings/SettingsFragment.kt
@@ -26,11 +26,14 @@ import android.net.Uri
 import android.os.Bundle
 import android.provider.Settings
 import android.util.Log
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
+import androidx.recyclerview.widget.RecyclerView
 import org.isoron.uhabits.HabitsApplication
 import org.isoron.uhabits.R
 import org.isoron.uhabits.activities.habits.list.RESULT_BUG_REPORT
@@ -44,6 +47,7 @@ import org.isoron.uhabits.core.utils.DateUtils.Companion.getLongWeekdayNames
 import org.isoron.uhabits.notifications.AndroidNotificationTray.Companion.createAndroidNotificationChannel
 import org.isoron.uhabits.notifications.RingtoneManager
 import org.isoron.uhabits.utils.StyledResources
+import org.isoron.uhabits.utils.applyBottomInset
 import org.isoron.uhabits.utils.startActivitySafely
 import org.isoron.uhabits.widgets.WidgetUpdater
 import java.util.Calendar
@@ -92,6 +96,15 @@ class SettingsFragment : PreferenceFragmentCompat(), OnSharedPreferenceChangeLis
         val sr = StyledResources(context!!)
         view.setBackgroundColor(sr.getColor(R.attr.contrast0))
         super.onViewCreated(view, savedInstanceState)
+    }
+
+    override fun onCreateRecyclerView(
+        inflater: LayoutInflater?,
+        parent: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): RecyclerView? {
+        return super.onCreateRecyclerView(inflater, parent, savedInstanceState)
+            .also { it.applyBottomInset() }
     }
 
     override fun onPreferenceTreeClick(preference: Preference): Boolean {

--- a/uhabits-android/src/main/res/values/styles.xml
+++ b/uhabits-android/src/main/res/values/styles.xml
@@ -160,7 +160,7 @@
     </style>
 
     <style name="PreferenceThemeOverlay.v14.Material.PureBlack">
-        <item name="android:background">@color/black</item>
+        <item name="colorControlHighlight">@color/white_a0</item>
     </style>
 
 


### PR DESCRIPTION
This PR contains 2 improvements (open for discussion)

# 1. Ripple effect in Settings screen on Pure Dark theme was little bit broken 


- On screenshots - item is pressed
-  Better visible on **AMOLED** device, than on screenshot
### Before - contains highlighting around black color filling:
<img width="716" height="340" alt="image" src="https://github.com/user-attachments/assets/5e593159-a335-4e3c-bb40-2fb8385754eb" />


### After - highlighting is all over item, but little bit dimmer:
<img width="624" height="363" alt="image" src="https://github.com/user-attachments/assets/394ce66f-692c-4756-b317-81053597a70b" />


# 2. Processed bottom insets more correctly (on any theme)


## Before - navigation bar is solid color

<img width="476" height="124" alt="image" src="https://github.com/user-attachments/assets/f6f52ce5-ac3f-4f91-a91f-a8531ccc0768" />

<img width="475" height="128" alt="image" src="https://github.com/user-attachments/assets/958cd731-18ba-4897-ab43-0b4f5df1aa1c" />

<img width="478" height="88" alt="image" src="https://github.com/user-attachments/assets/2e467609-080e-4237-b1b4-51af9b66ad66" />

<img width="476" height="85" alt="image" src="https://github.com/user-attachments/assets/07fc4c43-d500-44c7-9774-02a917ea1c49" />



## After - semi-transparent (3buttons) and transparent (gesture mode)


<img width="475" height="119" alt="image" src="https://github.com/user-attachments/assets/285a41fd-460b-41b6-b612-77c80038ad4c" />

<img width="473" height="138" alt="image" src="https://github.com/user-attachments/assets/9528beeb-f826-47a7-b9b3-cb54c7c8269d" />

<img width="477" height="126" alt="image" src="https://github.com/user-attachments/assets/0eb0737d-ba04-496d-8c5f-20cd8026631c" />

<img width="476" height="114" alt="image" src="https://github.com/user-attachments/assets/db36f0e4-d91e-4c75-98ea-d9fc356a9867" />

<img width="382" height="44" alt="image" src="https://github.com/user-attachments/assets/a939bdde-46a4-4850-863b-13de70266511" />
<img width="380" height="51" alt="image" src="https://github.com/user-attachments/assets/bf6cdb8f-f57f-46fb-a702-3aa77806439d" />


