### PR TITLE
Improvement:  UI performance of Habit List drag&drop

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/ButtonPanelView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/ButtonPanelView.kt
@@ -36,12 +36,14 @@ abstract class ButtonPanelView<T : View>(
 
     var buttonCount = 0
         set(value) {
+            if (field == value) return
             field = value
             inflateButtons()
         }
 
     var dataOffset = 0
         set(value) {
+            if (field == value) return
             field = value
             setupButtons()
         }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/CheckmarkButtonView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/CheckmarkButtonView.kt
@@ -135,6 +135,7 @@ class CheckmarkButtonView(
         private val bgColor = sres.getColor(R.attr.cardBgColor)
         private val lowContrastColor = sres.getColor(R.attr.contrast40)
         private val mediumContrastColor = sres.getColor(R.attr.contrast60)
+        private val pNotesIndicator = Paint()
 
         private val paint = TextPaint().apply {
             typeface = getFontAwesome()
@@ -192,7 +193,13 @@ class CheckmarkButtonView(
                 canvas.drawText(label, rect.centerX(), rect.centerY(), paint)
             }
 
-            drawNotesIndicator(canvas, color, em, notes)
+            drawNotesIndicator(
+                pNotesIndicator = pNotesIndicator,
+                canvas = canvas,
+                color = color,
+                size = em,
+                notes = notes,
+            )
         }
     }
 }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/HabitCardListAdapter.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/HabitCardListAdapter.kt
@@ -70,6 +70,8 @@ class HabitCardListAdapter @Inject constructor(
      * Sets all items as not selected.
      */
     override fun clearSelection() {
+        if (selected.isEmpty()) return
+
         selected.clear()
         notifyDataSetChanged()
         observable.notifyListeners()

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/NumberButtonView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/NumberButtonView.kt
@@ -145,6 +145,8 @@ class NumberButtonView(
         private val lowContrast: Int
         private val mediumContrast: Int
 
+        private val pNotesIndicator = Paint()
+
         private val paint = TextPaint().apply {
             typeface = getFontAwesome()
             isAntiAlias = true
@@ -234,7 +236,13 @@ class NumberButtonView(
                 canvas.drawText(trimmedUnits, rect.centerX(), rect.centerY(), pUnit)
             }
 
-            drawNotesIndicator(canvas, color, em, notes)
+            drawNotesIndicator(
+                pNotesIndicator = pNotesIndicator,
+                canvas = canvas,
+                color = color,
+                size = em,
+                notes = notes,
+            )
         }
     }
 }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/utils/ViewExtensions.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/utils/ViewExtensions.kt
@@ -210,13 +210,18 @@ fun View.sp(value: Float) = InterfaceUtils.spToPixels(context, value)
 fun View.dp(value: Float) = InterfaceUtils.dpToPixels(context, value)
 fun View.str(id: Int) = resources.getString(id)
 
-fun View.drawNotesIndicator(canvas: Canvas, color: Int, size: Float, notes: String) {
-    val pNotesIndicator = Paint()
+fun View.drawNotesIndicator(
+    pNotesIndicator: Paint,
+    canvas: Canvas,
+    color: Int,
+    size: Float,
+    notes: String,
+) {
+    if (notes.isBlank()) return
+
     pNotesIndicator.color = color
-    if (notes.isNotBlank()) {
-        val cy = 0.8f * size
-        canvas.drawCircle(width.toFloat() - cy, cy, 8f, pNotesIndicator)
-    }
+    val cy = 0.8f * size
+    canvas.drawCircle(width.toFloat() - cy, cy, 8f, pNotesIndicator)
 }
 
 val View.sres: StyledResources


### PR DESCRIPTION
Optimised performance of Habits List little bit.
List of improvements:
- Remove unneeded calls to notifyDataSetChanged() when clearselection() is called
- removed init of Paint() in View.drawNotesIndicator()  (it was in onDraw)
- remove some button reinflation when data in view changes

I've tried AA of these changes - and hopefully not broken anything - but you can recheck additionally, thanks!

### Before
https://github.com/user-attachments/assets/9685fdcc-9f30-4469-97cf-6b1ba55ac8e5
### After
https://github.com/user-attachments/assets/941084b2-5e00-4033-9662-9eabb072b2b1


