### PR TITLE
Yash widgets mini dashboard

### DIFF
--- a/uhabits-android/src/main/AndroidManifest.xml
+++ b/uhabits-android/src/main/AndroidManifest.xml
@@ -145,6 +145,11 @@
             android:exported="false"
             android:permission="android.permission.BIND_REMOTEVIEWS" />
 
+        <service
+            android:name=".widgets.GridWidgetService"
+            android:exported="false"
+            android:permission="android.permission.BIND_REMOTEVIEWS" />
+
         <receiver
             android:name=".widgets.HistoryWidgetProvider"
             android:exported="true"

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/ScrollableChart.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/ScrollableChart.kt
@@ -28,11 +28,11 @@ import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.View
 import android.widget.Scroller
+import org.isoron.uhabits.core.utils.DateUtils.Companion.getMonthsSince1970
+import org.isoron.uhabits.core.utils.DateUtils.Companion.getStartOfTodayCalendar
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
-import org.isoron.uhabits.core.utils.DateUtils.Companion.getMonthsSince1970
-import org.isoron.uhabits.core.utils.DateUtils.Companion.getStartOfTodayCalendar
 
 abstract class ScrollableChart : View, GestureDetector.OnGestureListener, AnimatorUpdateListener {
     var dataOffset = 0

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/CheckmarkButtonView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/CheckmarkButtonView.kt
@@ -198,7 +198,7 @@ class CheckmarkButtonView(
                 canvas = canvas,
                 color = color,
                 size = em,
-                notes = notes,
+                notes = notes
             )
         }
     }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/NumberButtonView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/views/NumberButtonView.kt
@@ -241,7 +241,7 @@ class NumberButtonView(
                 canvas = canvas,
                 color = color,
                 size = em,
-                notes = notes,
+                notes = notes
             )
         }
     }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/settings/SettingsFragment.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/settings/SettingsFragment.kt
@@ -114,7 +114,7 @@ class SettingsFragment : PreferenceFragmentCompat(), OnSharedPreferenceChangeLis
     override fun onCreateRecyclerView(
         inflater: LayoutInflater?,
         parent: ViewGroup?,
-        savedInstanceState: Bundle?,
+        savedInstanceState: Bundle?
     ): RecyclerView? {
         return super.onCreateRecyclerView(inflater, parent, savedInstanceState)
             .also { it.applyBottomInset() }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/utils/ViewExtensions.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/utils/ViewExtensions.kt
@@ -215,7 +215,7 @@ fun View.drawNotesIndicator(
     canvas: Canvas,
     color: Int,
     size: Float,
-    notes: String,
+    notes: String
 ) {
     if (notes.isBlank()) return
 

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/CheckmarkWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/CheckmarkWidget.kt
@@ -61,6 +61,9 @@ open class CheckmarkWidget(
                 entryState = habit.computedEntries.get(today).value
             }
             percentage = habit.scores[today].value.toFloat()
+            streakDays = WidgetHabitStats.computeCurrentStreakDays(habit, today)
+            weeklySuccess = WidgetHabitStats.computeWeeklySuccess(habit, today)
+            nextReminderTimeUtcMillis = WidgetHabitStats.computeNextReminderTimeUtcMillis(habit, System.currentTimeMillis())
             refresh()
         }
     }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/FrequencyWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/FrequencyWidget.kt
@@ -26,6 +26,7 @@ import org.isoron.platform.gui.toInt
 import org.isoron.uhabits.activities.common.views.FrequencyChart
 import org.isoron.uhabits.core.models.Habit
 import org.isoron.uhabits.core.ui.views.WidgetTheme
+import org.isoron.uhabits.core.utils.DateUtils
 import org.isoron.uhabits.widgets.views.GraphWidgetView
 
 class FrequencyWidget(
@@ -46,6 +47,15 @@ class FrequencyWidget(
         widgetView.setTitle(habit.name)
         widgetView.setBackgroundAlpha(preferedBackgroundAlpha)
         if (preferedBackgroundAlpha >= 255) widgetView.setShadowAlpha(0x4f)
+
+        val today = DateUtils.getTodayWithOffset()
+        val accent = WidgetTheme().color(habit.color).toInt()
+        widgetView.setExtras(
+            accentColor = accent,
+            streakDays = WidgetHabitStats.computeCurrentStreakDays(habit, today),
+            weeklySuccess = WidgetHabitStats.computeWeeklySuccess(habit, today),
+            nextReminderTimeUtcMillis = WidgetHabitStats.computeNextReminderTimeUtcMillis(habit, System.currentTimeMillis())
+        )
         (widgetView.dataView as FrequencyChart).apply {
             setFirstWeekday(firstWeekday)
             setColor(WidgetTheme().color(habit.color).toInt())

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/GridWidgetService.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/GridWidgetService.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2016-2025 Álinson Santos Xavier <git@axavier.org>
+ *
+ * This file is part of Loop Habit Tracker.
+ *
+ * Loop Habit Tracker is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * Loop Habit Tracker is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.isoron.uhabits.widgets
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.os.Looper
+import android.util.Log
+import android.widget.RemoteViews
+import android.widget.RemoteViewsService
+import android.widget.RemoteViewsService.RemoteViewsFactory
+import org.isoron.platform.utils.StringUtils.Companion.splitLongs
+import org.isoron.uhabits.HabitsApplication
+import org.isoron.uhabits.R
+import org.isoron.uhabits.core.models.Habit
+import org.isoron.uhabits.core.models.HabitNotFoundException
+import org.isoron.uhabits.core.preferences.Preferences
+import org.isoron.uhabits.core.utils.DateUtils.Companion.getTodayWithOffset
+import org.isoron.uhabits.intents.IntentFactory
+import org.isoron.uhabits.intents.PendingIntentFactory
+import org.isoron.uhabits.utils.InterfaceUtils.dpToPixels
+import kotlin.math.max
+
+class GridWidgetService : RemoteViewsService() {
+    override fun onGetViewFactory(intent: Intent): RemoteViewsFactory {
+        return GridRemoteViewsFactory(this.applicationContext, intent)
+    }
+
+    companion object {
+        const val WIDGET_TYPE = "WIDGET_TYPE"
+        const val HABIT_IDS = "HABIT_IDS"
+    }
+}
+
+internal class GridRemoteViewsFactory(private val context: Context, intent: Intent) :
+    RemoteViewsFactory {
+
+    private val widgetId: Int = intent.getIntExtra(
+        AppWidgetManager.EXTRA_APPWIDGET_ID,
+        AppWidgetManager.INVALID_APPWIDGET_ID
+    )
+
+    private val habitIds: LongArray
+    private val widgetType: StackWidgetType
+
+    override fun onCreate() {}
+    override fun onDestroy() {}
+
+    override fun getCount(): Int = habitIds.size
+
+    override fun getViewAt(position: Int): RemoteViews? {
+        Log.i("GridRemoteViewsFactory", "getViewAt $position started")
+        if (position < 0 || position >= habitIds.size) return null
+
+        val app = context.applicationContext as HabitsApplication
+        val prefs = app.component.preferences
+        val habitList = app.component.habitList
+
+        val options = AppWidgetManager.getInstance(context).getAppWidgetOptions(widgetId)
+        if (Looper.myLooper() == null) Looper.prepare()
+
+        val habits = habitIds.map { habitList.getById(it) ?: throw HabitNotFoundException() }
+        val h = habits[position]
+
+        val widget = constructWidget(h, prefs)
+        widget.setDimensions(buildCellDimensions(context, options))
+
+        val landscapeViews = widget.landscapeRemoteViews
+        val portraitViews = widget.portraitRemoteViews
+
+        val factory = PendingIntentFactory(context, IntentFactory())
+        val intent = StackWidgetType.getIntentFillIn(
+            factory,
+            widgetType,
+            h,
+            habits,
+            getTodayWithOffset()
+        )
+        landscapeViews.setOnClickFillInIntent(R.id.button, intent)
+        portraitViews.setOnClickFillInIntent(R.id.button, intent)
+
+        val remoteViews = RemoteViews(landscapeViews, portraitViews)
+        Log.i("GridRemoteViewsFactory", "getViewAt $position ended")
+        return remoteViews
+    }
+
+    private fun constructWidget(habit: Habit, prefs: Preferences): BaseWidget {
+        return when (widgetType) {
+            StackWidgetType.CHECKMARK -> CheckmarkWidget(context, widgetId, habit, true)
+            StackWidgetType.FREQUENCY -> FrequencyWidget(context, widgetId, habit, prefs.firstWeekdayInt, true)
+            StackWidgetType.SCORE -> ScoreWidget(context, widgetId, habit, true)
+            StackWidgetType.HISTORY -> HistoryWidget(context, widgetId, habit, true)
+            StackWidgetType.STREAKS -> StreakWidget(context, widgetId, habit, true)
+            StackWidgetType.TARGET -> TargetWidget(context, widgetId, habit, true)
+        }
+    }
+
+    private fun getDimensionsFromOptions(ctx: Context, options: Bundle): WidgetDimensions {
+        val maxWidth = dpToPixels(
+            ctx,
+            options.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_WIDTH).toFloat()
+        ).toInt()
+        val maxHeight = dpToPixels(
+            ctx,
+            options.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT).toFloat()
+        ).toInt()
+        val minWidth = dpToPixels(
+            ctx,
+            options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH).toFloat()
+        ).toInt()
+        val minHeight = dpToPixels(
+            ctx,
+            options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT).toFloat()
+        ).toInt()
+        return WidgetDimensions(minWidth, maxHeight, maxWidth, minHeight)
+    }
+
+    private fun buildCellDimensions(ctx: Context, options: Bundle): WidgetDimensions {
+        val dims = getDimensionsFromOptions(ctx, options)
+        val portraitCell = computeCellSize(dims.portraitWidth)
+        val landscapeCell = computeCellSize(dims.landscapeWidth)
+        return WidgetDimensions(
+            portraitCell,
+            portraitCell,
+            landscapeCell,
+            landscapeCell
+        )
+    }
+
+    private fun computeCellSize(totalWidthPx: Int): Int {
+        val minCell = dpToPixels(context, 140f).toInt()
+        val columns = (totalWidthPx / max(1, minCell)).coerceIn(1, 4)
+        return max(1, totalWidthPx / columns)
+    }
+
+    override fun getLoadingView(): RemoteViews {
+        val options = AppWidgetManager.getInstance(context).getAppWidgetOptions(widgetId)
+        val widget = EmptyWidget(context, widgetId)
+        widget.setDimensions(buildCellDimensions(context, options))
+        val landscapeViews = widget.landscapeRemoteViews
+        val portraitViews = widget.portraitRemoteViews
+        return RemoteViews(landscapeViews, portraitViews)
+    }
+
+    override fun getViewTypeCount(): Int = 1
+
+    override fun getItemId(position: Int): Long = habitIds[position]
+
+    override fun hasStableIds(): Boolean = true
+
+    override fun onDataSetChanged() {}
+
+    init {
+        val widgetTypeValue = intent.getIntExtra(GridWidgetService.WIDGET_TYPE, -1)
+        val habitIdsStr = intent.getStringExtra(GridWidgetService.HABIT_IDS)
+        if (widgetTypeValue < 0) throw RuntimeException("invalid widget type")
+        if (habitIdsStr == null) throw RuntimeException("habitIdsStr is null")
+
+        widgetType = StackWidgetType.getWidgetTypeFromValue(widgetTypeValue)
+            ?: throw RuntimeException("unknown widget type value: $widgetTypeValue")
+        habitIds = splitLongs(habitIdsStr)
+    }
+}

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/HistoryWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/HistoryWidget.kt
@@ -23,6 +23,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.view.View
 import org.isoron.platform.gui.AndroidDataView
+import org.isoron.platform.gui.toInt
 import org.isoron.platform.time.JavaLocalDateFormatter
 import org.isoron.uhabits.core.models.Habit
 import org.isoron.uhabits.core.ui.screens.habits.show.views.HistoryCardPresenter
@@ -50,6 +51,15 @@ class HistoryWidget(
         val widgetView = view as GraphWidgetView
         widgetView.setBackgroundAlpha(preferedBackgroundAlpha)
         if (preferedBackgroundAlpha >= 255) widgetView.setShadowAlpha(0x4f)
+
+        val today = DateUtils.getTodayWithOffset()
+        val accent = WidgetTheme().color(habit.color).toInt()
+        widgetView.setExtras(
+            accentColor = accent,
+            streakDays = WidgetHabitStats.computeCurrentStreakDays(habit, today),
+            weeklySuccess = WidgetHabitStats.computeWeeklySuccess(habit, today),
+            nextReminderTimeUtcMillis = WidgetHabitStats.computeNextReminderTimeUtcMillis(habit, System.currentTimeMillis())
+        )
         val model = HistoryCardPresenter.buildState(
             habit = habit,
             firstWeekday = prefs.firstWeekday,

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/ScoreWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/ScoreWidget.kt
@@ -27,6 +27,7 @@ import org.isoron.uhabits.activities.common.views.ScoreChart
 import org.isoron.uhabits.core.models.Habit
 import org.isoron.uhabits.core.ui.screens.habits.show.views.ScoreCardPresenter
 import org.isoron.uhabits.core.ui.views.WidgetTheme
+import org.isoron.uhabits.core.utils.DateUtils
 import org.isoron.uhabits.widgets.views.GraphWidgetView
 
 class ScoreWidget(
@@ -51,6 +52,15 @@ class ScoreWidget(
         val widgetView = view as GraphWidgetView
         widgetView.setBackgroundAlpha(preferedBackgroundAlpha)
         if (preferedBackgroundAlpha >= 255) widgetView.setShadowAlpha(0x4f)
+
+        val today = DateUtils.getTodayWithOffset()
+        val accent = WidgetTheme().color(habit.color).toInt()
+        widgetView.setExtras(
+            accentColor = accent,
+            streakDays = WidgetHabitStats.computeCurrentStreakDays(habit, today),
+            weeklySuccess = WidgetHabitStats.computeWeeklySuccess(habit, today),
+            nextReminderTimeUtcMillis = WidgetHabitStats.computeNextReminderTimeUtcMillis(habit, System.currentTimeMillis())
+        )
         (widgetView.dataView as ScoreChart).apply {
             setIsTransparencyEnabled(true)
             setBucketSize(viewModel.bucketSize)

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/StackWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/StackWidget.kt
@@ -24,10 +24,15 @@ import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.text.format.DateFormat
 import android.view.View
 import android.widget.RemoteViews
 import org.isoron.platform.utils.StringUtils
+import org.isoron.uhabits.R
 import org.isoron.uhabits.core.models.Habit
+import org.isoron.uhabits.utils.InterfaceUtils.dpToPixels
+import java.util.Date
+import kotlin.math.max
 
 class StackWidget(
     context: Context,
@@ -52,31 +57,74 @@ class StackWidget(
 
     override fun getRemoteViews(width: Int, height: Int): RemoteViews {
         val manager = AppWidgetManager.getInstance(context)
+        val habitIds = StringUtils.joinLongs(habits.map { it.id!! }.toLongArray())
+
+        if (widgetType == StackWidgetType.CHECKMARK && shouldUseCheckmarkGrid(width, height)) {
+            val remoteViews = RemoteViews(context.packageName, R.layout.checkmark_gridview_widget)
+            val serviceIntent = Intent(context, GridWidgetService::class.java)
+
+            serviceIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, id)
+            serviceIntent.putExtra(GridWidgetService.WIDGET_TYPE, widgetType.value)
+            serviceIntent.putExtra(GridWidgetService.HABIT_IDS, habitIds)
+            serviceIntent.data = Uri.parse(serviceIntent.toUri(Intent.URI_INTENT_SCHEME))
+
+            remoteViews.setRemoteAdapter(R.id.checkmarkGridWidgetView, serviceIntent)
+            manager.notifyAppWidgetViewDataChanged(id, R.id.checkmarkGridWidgetView)
+            remoteViews.setEmptyView(R.id.checkmarkGridWidgetView, R.id.checkmarkGridWidgetEmptyView)
+
+            val doneCount = habits.count { it.isCompletedToday() }
+            remoteViews.setTextViewText(
+                R.id.checkmarkGridWidgetSummary,
+                context.getString(R.string.widget_dashboard_done_summary, doneCount, habits.size)
+            )
+
+            val now = System.currentTimeMillis()
+            val next = habits.mapNotNull { WidgetHabitStats.computeNextReminderTimeUtcMillis(it, now) }.minOrNull()
+            if (next != null) {
+                val timeStr = DateFormat.getTimeFormat(context).format(Date(next))
+                remoteViews.setViewVisibility(R.id.checkmarkGridWidgetNext, View.VISIBLE)
+                remoteViews.setTextViewText(
+                    R.id.checkmarkGridWidgetNext,
+                    context.getString(R.string.widget_next_reminder_at, timeStr)
+                )
+            } else {
+                remoteViews.setViewVisibility(R.id.checkmarkGridWidgetNext, View.GONE)
+            }
+
+            remoteViews.setPendingIntentTemplate(
+                R.id.checkmarkGridWidgetView,
+                StackWidgetType.getPendingIntentTemplate(pendingIntentFactory, widgetType, habits)
+            )
+
+            return remoteViews
+        }
+
         val remoteViews =
             RemoteViews(context.packageName, StackWidgetType.getStackWidgetLayoutId(widgetType))
         val serviceIntent = Intent(context, StackWidgetService::class.java)
-        val habitIds = StringUtils.joinLongs(habits.map { it.id!! }.toLongArray())
 
         serviceIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, id)
         serviceIntent.putExtra(StackWidgetService.WIDGET_TYPE, widgetType.value)
         serviceIntent.putExtra(StackWidgetService.HABIT_IDS, habitIds)
         serviceIntent.data = Uri.parse(serviceIntent.toUri(Intent.URI_INTENT_SCHEME))
-        remoteViews.setRemoteAdapter(
-            StackWidgetType.getStackWidgetAdapterViewId(widgetType),
-            serviceIntent
-        )
-        manager.notifyAppWidgetViewDataChanged(
-            id,
-            StackWidgetType.getStackWidgetAdapterViewId(widgetType)
-        )
-        remoteViews.setEmptyView(
-            StackWidgetType.getStackWidgetAdapterViewId(widgetType),
-            StackWidgetType.getStackWidgetEmptyViewId(widgetType)
-        )
+
+        val adapterViewId = StackWidgetType.getStackWidgetAdapterViewId(widgetType)
+        remoteViews.setRemoteAdapter(adapterViewId, serviceIntent)
+        manager.notifyAppWidgetViewDataChanged(id, adapterViewId)
+        remoteViews.setEmptyView(adapterViewId, StackWidgetType.getStackWidgetEmptyViewId(widgetType))
         remoteViews.setPendingIntentTemplate(
-            StackWidgetType.getStackWidgetAdapterViewId(widgetType),
+            adapterViewId,
             StackWidgetType.getPendingIntentTemplate(pendingIntentFactory, widgetType, habits)
         )
+
         return remoteViews
+    }
+
+    private fun shouldUseCheckmarkGrid(width: Int, height: Int): Boolean {
+        if (habits.size < 3) return false
+        val minCell = dpToPixels(context, 140f).toInt()
+        val columns = max(1, width / max(1, minCell))
+        val rows = max(1, height / max(1, minCell))
+        return columns >= 2 && rows >= 2
     }
 }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/StreakWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/StreakWidget.kt
@@ -28,6 +28,7 @@ import org.isoron.platform.gui.toInt
 import org.isoron.uhabits.activities.common.views.StreakChart
 import org.isoron.uhabits.core.models.Habit
 import org.isoron.uhabits.core.ui.views.WidgetTheme
+import org.isoron.uhabits.core.utils.DateUtils
 import org.isoron.uhabits.widgets.views.GraphWidgetView
 
 class StreakWidget(
@@ -46,6 +47,15 @@ class StreakWidget(
         val widgetView = view as GraphWidgetView
         widgetView.setBackgroundAlpha(preferedBackgroundAlpha)
         if (preferedBackgroundAlpha >= 255) widgetView.setShadowAlpha(0x4f)
+
+        val today = DateUtils.getTodayWithOffset()
+        val accent = WidgetTheme().color(habit.color).toInt()
+        widgetView.setExtras(
+            accentColor = accent,
+            streakDays = WidgetHabitStats.computeCurrentStreakDays(habit, today),
+            weeklySuccess = WidgetHabitStats.computeWeeklySuccess(habit, today),
+            nextReminderTimeUtcMillis = WidgetHabitStats.computeNextReminderTimeUtcMillis(habit, System.currentTimeMillis())
+        )
         (widgetView.dataView as StreakChart).apply {
             setColor(WidgetTheme().color(habit.color).toInt())
             setStreaks(habit.streaks.getBest(maxStreakCount))

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/TargetWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/TargetWidget.kt
@@ -31,6 +31,7 @@ import org.isoron.uhabits.activities.habits.show.views.TargetCardView.Companion.
 import org.isoron.uhabits.core.models.Habit
 import org.isoron.uhabits.core.ui.screens.habits.show.views.TargetCardPresenter
 import org.isoron.uhabits.core.ui.views.WidgetTheme
+import org.isoron.uhabits.core.utils.DateUtils
 import org.isoron.uhabits.widgets.views.GraphWidgetView
 
 class TargetWidget(
@@ -49,7 +50,16 @@ class TargetWidget(
         val widgetView = view as GraphWidgetView
         widgetView.setBackgroundAlpha(preferedBackgroundAlpha)
         if (preferedBackgroundAlpha >= 255) widgetView.setShadowAlpha(0x4f)
-        val chart = (widgetView.dataView as TargetChart)
+
+        val today = DateUtils.getTodayWithOffset()
+        val accent = WidgetTheme().color(habit.color).toInt()
+        widgetView.setExtras(
+            accentColor = accent,
+            streakDays = WidgetHabitStats.computeCurrentStreakDays(habit, today),
+            weeklySuccess = WidgetHabitStats.computeWeeklySuccess(habit, today),
+            nextReminderTimeUtcMillis = WidgetHabitStats.computeNextReminderTimeUtcMillis(habit, System.currentTimeMillis())
+        )
+        val chart = widgetView.dataView as TargetChart
         val data = TargetCardPresenter.buildState(
             habit = habit,
             firstWeekday = prefs.firstWeekdayInt,

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/WidgetHabitStats.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/WidgetHabitStats.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2016-2025 Álinson Santos Xavier <git@axavier.org>
+ *
+ * This file is part of Loop Habit Tracker.
+ *
+ * Loop Habit Tracker is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * Loop Habit Tracker is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.isoron.uhabits.widgets
+
+import org.isoron.uhabits.core.models.Entry
+import org.isoron.uhabits.core.models.Habit
+import org.isoron.uhabits.core.models.NumericalHabitType
+import org.isoron.uhabits.core.models.Timestamp
+import org.isoron.uhabits.core.utils.DateUtils
+
+internal object WidgetHabitStats {
+
+    fun computeCurrentStreakDays(habit: Habit, today: Timestamp): Int {
+        val todayValue = habit.computedEntries.get(today).value
+        val isTodayEntered = todayValue != Entry.UNKNOWN
+
+        val streakEnd: Timestamp = when {
+            isSuccessOn(habit, today) -> today
+            !isTodayEntered -> today.minus(1)
+            else -> return 0
+        }
+
+        var length = 0
+        var current = streakEnd
+        while (length < 3650 && isSuccessOn(habit, current)) {
+            length++
+            current = current.minus(1)
+        }
+
+        return length
+    }
+
+    /**
+     * Seven values (oldest -> newest), ending at [today].
+     */
+    fun computeWeeklySuccess(habit: Habit, today: Timestamp): BooleanArray {
+        val result = BooleanArray(7)
+        for (i in 0 until 7) {
+            val day = today.minus(6 - i)
+            result[i] = isSuccessOn(habit, day)
+        }
+        return result
+    }
+
+    /**
+     * Returns the next reminder time (UTC millis) that should actually show, respecting the
+     * reminder weekday selection and the user's start-of-day offset.
+     */
+    fun computeNextReminderTimeUtcMillis(habit: Habit, nowUtcMillis: Long): Long? {
+        val reminder = habit.reminder ?: return null
+        val allowedDays = if (reminder.days.isEmpty) {
+            BooleanArray(7) { true }
+        } else {
+            reminder.days.toArray()
+        }
+
+        val nowLocal = DateUtils.getLocalTime(nowUtcMillis)
+        val todayStartLocal = DateUtils.getStartOfDay(nowLocal)
+
+        // Search up to two weeks ahead to be safe.
+        for (d in 0..13) {
+            val dayStartLocal = todayStartLocal + d * DateUtils.DAY_LENGTH
+            val candidateLocal =
+                dayStartLocal + reminder.hour * DateUtils.HOUR_LENGTH + reminder.minute * DateUtils.MINUTE_LENGTH
+
+            val candidateUtc = DateUtils.applyTimezone(candidateLocal)
+            if (candidateUtc <= nowUtcMillis) continue
+
+            val habitDayStartLocal = DateUtils.getStartOfDayWithOffset(DateUtils.removeTimezone(candidateUtc))
+            val weekday = Timestamp(habitDayStartLocal).weekday
+            if (allowedDays[weekday]) return candidateUtc
+        }
+
+        return null
+    }
+
+    private fun isSuccessOn(habit: Habit, day: Timestamp): Boolean {
+        val value = habit.computedEntries.get(day).value
+        if (!habit.isNumerical) return value > 0
+
+        return when (habit.targetType) {
+            NumericalHabitType.AT_LEAST -> value / 1000.0 >= habit.targetValue
+            NumericalHabitType.AT_MOST -> value != Entry.UNKNOWN && value / 1000.0 <= habit.targetValue
+        }
+    }
+}

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/views/CheckmarkWidgetView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/views/CheckmarkWidgetView.kt
@@ -19,6 +19,8 @@
 package org.isoron.uhabits.widgets.views
 
 import android.content.Context
+import android.graphics.drawable.GradientDrawable
+import android.text.format.DateFormat
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.View
@@ -34,9 +36,11 @@ import org.isoron.uhabits.core.models.Entry.Companion.YES_AUTO
 import org.isoron.uhabits.core.models.Entry.Companion.YES_MANUAL
 import org.isoron.uhabits.core.preferences.Preferences
 import org.isoron.uhabits.inject.HabitsApplicationComponent
+import org.isoron.uhabits.utils.InterfaceUtils.dpToPixels
 import org.isoron.uhabits.utils.InterfaceUtils.getDimension
 import org.isoron.uhabits.utils.PaletteUtils.getAndroidTestColor
 import org.isoron.uhabits.utils.StyledResources
+import java.util.Date
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -46,12 +50,26 @@ class CheckmarkWidgetView : HabitWidgetView {
 
     var percentage = 0f
     var name: String? = null
-    private lateinit var ring: RingView
-    private lateinit var label: TextView
+
     var entryValue = 0
     var entryState = 0
     var isNumerical = false
+
+    var streakDays: Int = 0
+    var weeklySuccess: BooleanArray = BooleanArray(7)
+    var nextReminderTimeUtcMillis: Long? = null
+
+    private lateinit var ring: RingView
+    private lateinit var label: TextView
+    private lateinit var streakBadge: TextView
+    private lateinit var weeklyHeatmap: WeeklyHeatmapView
+    private lateinit var reminderLabel: TextView
+
     private var preferences: Preferences? = null
+
+    private val badgeBackground = GradientDrawable().apply {
+        shape = GradientDrawable.RECTANGLE
+    }
 
     constructor(context: Context?) : super(context) {
         init()
@@ -63,9 +81,16 @@ class CheckmarkWidgetView : HabitWidgetView {
 
     fun refresh() {
         if (backgroundPaint == null || frame == null) return
+
         val res = StyledResources(context)
+
         val bgColor: Int
         val fgColor: Int
+        val isActive = when (entryState) {
+            YES_MANUAL, SKIP, YES_AUTO -> true
+            else -> false
+        }
+
         setShadowAlpha(0x4f)
         when (entryState) {
             YES_MANUAL, SKIP, YES_AUTO -> {
@@ -83,13 +108,53 @@ class CheckmarkWidgetView : HabitWidgetView {
                 fgColor = res.getColor(R.attr.contrast60)
             }
         }
+
         ring.setPercentage(percentage)
         ring.setColor(fgColor)
         ring.setBackgroundColor(bgColor)
         ring.setText(text)
         ring.setIsStrokedTextEnabled(strokedTextEnabled)
+
         label.text = name
         label.setTextColor(fgColor)
+
+        // Streak badge
+        streakBadge.visibility = View.VISIBLE
+        streakBadge.text = max(0, streakDays).toString()
+
+        val badgeBg = if (isActive) fgColor else activeColor
+        val badgeFg = if (isActive) bgColor else res.getColor(R.attr.contrast0)
+
+        badgeBackground.setColor(withAlpha(badgeBg, if (isActive) 220 else 235))
+        badgeBackground.cornerRadius = dpToPixels(context, 999f)
+        badgeBackground.setStroke(
+            dpToPixels(context, 1f).roundToInt(),
+            withAlpha(badgeFg, 70)
+        )
+
+        streakBadge.background = badgeBackground
+        streakBadge.setTextColor(badgeFg)
+
+        // Weekly heatmap
+        weeklyHeatmap.cells = weeklySuccess
+        weeklyHeatmap.activeColor = if (isActive) fgColor else activeColor
+        weeklyHeatmap.inactiveColor = if (isActive) withAlpha(fgColor, 60) else res.getColor(R.attr.contrast20)
+        weeklyHeatmap.highlightIndex = 6
+
+        val showHeatmap = shouldShowHeatmap(measuredWidth, measuredHeight)
+        weeklyHeatmap.visibility = if (showHeatmap) View.VISIBLE else View.GONE
+
+        // Next reminder label
+        val reminderTime = nextReminderTimeUtcMillis
+        if (reminderTime != null && shouldShowReminder(measuredWidth, measuredHeight)) {
+            reminderLabel.visibility = View.VISIBLE
+            val timeStr = DateFormat.getTimeFormat(context).format(Date(reminderTime))
+            reminderLabel.text = resources.getString(R.string.widget_next_reminder_at, timeStr)
+            reminderLabel.setTextColor(fgColor)
+        } else {
+            reminderLabel.visibility = View.GONE
+        }
+
         requestLayout()
         postInvalidate()
     }
@@ -111,14 +176,9 @@ class CheckmarkWidgetView : HabitWidgetView {
             when (entryState) {
                 YES_MANUAL, YES_AUTO -> resources.getString(R.string.fa_check)
                 SKIP -> resources.getString(R.string.fa_skipped)
-                UNKNOWN -> {
-                    run {
-                        if (preferences!!.areQuestionMarksEnabled) {
-                            return resources.getString(R.string.fa_question)
-                        } else {
-                            resources.getString(R.string.fa_times)
-                        }
-                    }
+                UNKNOWN -> if (preferences?.areQuestionMarksEnabled == true) {
+                    resources.getString(R.string.fa_question)
+                } else {
                     resources.getString(R.string.fa_times)
                 }
                 NO -> resources.getString(R.string.fa_times)
@@ -132,19 +192,34 @@ class CheckmarkWidgetView : HabitWidgetView {
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         var width = MeasureSpec.getSize(widthMeasureSpec)
         var height = MeasureSpec.getSize(heightMeasureSpec)
+
         if (height >= width) {
             height = min(height, (width * 1.5).roundToInt())
         } else {
             width = min(width, height)
         }
+
         val textSize = min(0.175f * width, getDimension(context, R.dimen.smallTextSize))
         label.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize)
+        reminderLabel.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize * 0.70f)
+        streakBadge.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize * 0.75f)
+
         if (isNumerical) {
             ring.setTextSize(textSize * 0.9f)
         } else {
             ring.setTextSize(textSize)
         }
+
         ring.setThickness(0.03f * width)
+
+        // Scale the heatmap height a bit with the widget size.
+        weeklyHeatmap.layoutParams = weeklyHeatmap.layoutParams.apply {
+            height = max(
+                dpToPixels(context, 12f).roundToInt(),
+                (0.08f * width).roundToInt()
+            )
+        }
+
         super.onMeasure(
             MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
             MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
@@ -154,16 +229,48 @@ class CheckmarkWidgetView : HabitWidgetView {
     private fun init() {
         val appComponent: HabitsApplicationComponent =
             (context.applicationContext as HabitsApplication).component
+
         preferences = appComponent.preferences
+
         ring = findViewById<View>(R.id.scoreRing) as RingView
         label = findViewById<View>(R.id.label) as TextView
+        streakBadge = findViewById<View>(R.id.streakBadge) as TextView
+        weeklyHeatmap = findViewById<View>(R.id.weeklyHeatmap) as WeeklyHeatmapView
+        reminderLabel = findViewById<View>(R.id.reminderLabel) as TextView
+
         ring.setIsTransparencyEnabled(true)
+
         if (isInEditMode) {
             percentage = 0.75f
             name = "Wake up early"
             activeColor = getAndroidTestColor(6)
-            entryValue = YES_MANUAL
+            entryValue = 0
+            entryState = YES_MANUAL
+            streakDays = 12
+            weeklySuccess = booleanArrayOf(true, true, false, true, true, true, false)
+            nextReminderTimeUtcMillis = System.currentTimeMillis() + 2 * 60 * 60 * 1000
             refresh()
         }
+    }
+
+    private fun shouldShowHeatmap(width: Int, height: Int): Boolean {
+        if (width <= 0 || height <= 0) return false
+        val minDim = min(width, height).toFloat()
+        val bigEnough = minDim >= dpToPixels(context, 90f)
+        val tallEnough = height.toFloat() / width.toFloat() >= 1.05f
+        return bigEnough || tallEnough
+    }
+
+    private fun shouldShowReminder(width: Int, height: Int): Boolean {
+        if (width <= 0 || height <= 0) return false
+        val minDim = min(width, height).toFloat()
+        val bigEnough = minDim >= dpToPixels(context, 140f)
+        val tallEnough = height.toFloat() / width.toFloat() >= 1.15f
+        return bigEnough || tallEnough
+    }
+
+    private fun withAlpha(color: Int, alpha: Int): Int {
+        val a = alpha.coerceIn(0, 255)
+        return (color and 0x00ffffff) or (a shl 24)
     }
 }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/views/GraphWidgetView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/views/GraphWidgetView.kt
@@ -19,19 +19,80 @@
 package org.isoron.uhabits.widgets.views
 
 import android.content.Context
+import android.graphics.drawable.GradientDrawable
+import android.text.format.DateFormat
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import org.isoron.uhabits.R
+import org.isoron.uhabits.utils.InterfaceUtils.dpToPixels
+import org.isoron.uhabits.utils.StyledResources
+import java.util.Date
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
 
 class GraphWidgetView(context: Context?, val dataView: View) : HabitWidgetView(context) {
+
     private lateinit var title: TextView
-    fun setTitle(text: String?) {
-        title.text = text
+    private lateinit var dataContainer: ViewGroup
+
+    private lateinit var streakBadge: TextView
+    private lateinit var weeklyHeatmap: WeeklyHeatmapView
+    private lateinit var reminderLabel: TextView
+
+    private val badgeBackground = GradientDrawable().apply {
+        shape = GradientDrawable.RECTANGLE
     }
 
     override val innerLayoutId: Int
         get() = R.layout.widget_graph
+
+    fun setTitle(text: String?) {
+        title.text = text
+    }
+
+    fun setExtras(
+        accentColor: Int,
+        streakDays: Int,
+        weeklySuccess: BooleanArray,
+        nextReminderTimeUtcMillis: Long?
+    ) {
+        val res = StyledResources(context)
+
+        streakBadge.visibility = View.VISIBLE
+        streakBadge.text = max(0, streakDays).toString()
+
+        badgeBackground.setColor(withAlpha(accentColor, 235))
+        badgeBackground.cornerRadius = dpToPixels(context, 999f)
+        badgeBackground.setStroke(
+            dpToPixels(context, 1f).roundToInt(),
+            withAlpha(res.getColor(R.attr.contrast0), 70)
+        )
+
+        streakBadge.background = badgeBackground
+        streakBadge.setTextColor(res.getColor(R.attr.contrast0))
+
+        weeklyHeatmap.cells = weeklySuccess
+        weeklyHeatmap.activeColor = accentColor
+        weeklyHeatmap.inactiveColor = res.getColor(R.attr.contrast20)
+        weeklyHeatmap.highlightIndex = 6
+
+        weeklyHeatmap.visibility = if (shouldShowHeatmap(measuredWidth, measuredHeight)) {
+            View.VISIBLE
+        } else {
+            View.GONE
+        }
+
+        if (nextReminderTimeUtcMillis != null && shouldShowReminder(measuredWidth, measuredHeight)) {
+            reminderLabel.visibility = View.VISIBLE
+            val timeStr = DateFormat.getTimeFormat(context).format(Date(nextReminderTimeUtcMillis))
+            reminderLabel.text = resources.getString(R.string.widget_next_reminder_at, timeStr)
+            reminderLabel.setTextColor(res.getColor(R.attr.contrast60))
+        } else {
+            reminderLabel.visibility = View.GONE
+        }
+    }
 
     private fun init() {
         val params = ViewGroup.LayoutParams(
@@ -39,10 +100,37 @@ class GraphWidgetView(context: Context?, val dataView: View) : HabitWidgetView(c
             ViewGroup.LayoutParams.MATCH_PARENT
         )
         dataView.layoutParams = params
-        val innerFrame = findViewById<View>(R.id.innerFrame) as ViewGroup
-        innerFrame.addView(dataView)
+
+        dataContainer = findViewById<View>(R.id.dataContainer) as ViewGroup
+        dataContainer.addView(dataView)
+
         title = findViewById<View>(R.id.title) as TextView
         title.visibility = VISIBLE
+
+        streakBadge = findViewById<View>(R.id.streakBadge) as TextView
+        weeklyHeatmap = findViewById<View>(R.id.weeklyHeatmap) as WeeklyHeatmapView
+        reminderLabel = findViewById<View>(R.id.reminderLabel) as TextView
+    }
+
+    private fun shouldShowHeatmap(width: Int, height: Int): Boolean {
+        if (width <= 0 || height <= 0) return false
+        val minDim = min(width, height).toFloat()
+        val bigEnough = minDim >= dpToPixels(context, 90f)
+        val tallEnough = height.toFloat() / width.toFloat() >= 1.05f
+        return bigEnough || tallEnough
+    }
+
+    private fun shouldShowReminder(width: Int, height: Int): Boolean {
+        if (width <= 0 || height <= 0) return false
+        val minDim = min(width, height).toFloat()
+        val bigEnough = minDim >= dpToPixels(context, 140f)
+        val tallEnough = height.toFloat() / width.toFloat() >= 1.15f
+        return bigEnough || tallEnough
+    }
+
+    private fun withAlpha(color: Int, alpha: Int): Int {
+        val a = alpha.coerceIn(0, 255)
+        return (color and 0x00ffffff) or (a shl 24)
     }
 
     init {

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/views/WeeklyHeatmapView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/views/WeeklyHeatmapView.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2016-2025 Álinson Santos Xavier <git@axavier.org>
+ *
+ * This file is part of Loop Habit Tracker.
+ *
+ * Loop Habit Tracker is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * Loop Habit Tracker is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.isoron.uhabits.widgets.views
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.RectF
+import android.util.AttributeSet
+import android.view.View
+import kotlin.math.max
+import kotlin.math.min
+
+class WeeklyHeatmapView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : View(context, attrs) {
+
+    var cells: BooleanArray = BooleanArray(7)
+        set(value) {
+            field = value.copyOf(7)
+            invalidate()
+        }
+
+    var activeColor: Int = 0
+        set(value) {
+            field = value
+            invalidate()
+        }
+
+    var inactiveColor: Int = 0
+        set(value) {
+            field = value
+            invalidate()
+        }
+
+    /**
+     * Index of the cell to highlight (0..6). Set to a value outside the range to disable.
+     */
+    var highlightIndex: Int = 6
+        set(value) {
+            field = value
+            invalidate()
+        }
+
+    private val fillPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.FILL
+    }
+
+    private val strokePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+    }
+
+    private val rect = RectF()
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+
+        val w = width.toFloat()
+        val h = height.toFloat()
+        if (w <= 0f || h <= 0f) return
+
+        val minDim = min(w, h)
+        val targetGap = minDim * 0.10f
+        val availableW = w - targetGap * 6f
+        val cellSize = min(h, if (availableW > 0f) availableW / 7f else w / 7f)
+        val gap = max(0f, if (w > cellSize * 7f) (w - cellSize * 7f) / 6f else 0f)
+        val y = (h - cellSize) / 2f
+        val radius = cellSize * 0.22f
+
+        strokePaint.strokeWidth = max(1f, cellSize * 0.12f)
+
+        var x = 0f
+        for (i in 0 until 7) {
+            rect.set(x, y, x + cellSize, y + cellSize)
+            fillPaint.color = if (cells[i]) activeColor else inactiveColor
+            canvas.drawRoundRect(rect, radius, radius, fillPaint)
+
+            if (i == highlightIndex) {
+                strokePaint.color = activeColor
+                canvas.drawRoundRect(rect, radius, radius, strokePaint)
+            }
+
+            x += cellSize + gap
+        }
+    }
+}

--- a/uhabits-android/src/main/res/layout/checkmark_gridview_widget.xml
+++ b/uhabits-android/src/main/res/layout/checkmark_gridview_widget.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2016-2025 Álinson Santos Xavier <git@axavier.org>
+  ~
+  ~ This file is part of Loop Habit Tracker.
+  ~
+  ~ Loop Habit Tracker is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by the
+  ~ Free Software Foundation, either version 3 of the License, or (at your
+  ~ option) any later version.
+  ~
+  ~ Loop Habit Tracker is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+  ~ more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along
+  ~ with this program. If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingLeft="8dp"
+    android:paddingTop="8dp"
+    android:paddingRight="8dp"
+    android:paddingBottom="8dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/checkmarkGridWidgetTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:ellipsize="end"
+            android:fontFamily="sans-serif-condensed"
+            android:maxLines="1"
+            android:text="@string/today"
+            android:textColor="#ffffff"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/checkmarkGridWidgetSummary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:fontFamily="sans-serif-condensed"
+            android:gravity="end"
+            android:maxLines="1"
+            android:textColor="#ffffff"
+            android:textSize="12sp" />
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/checkmarkGridWidgetNext"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:ellipsize="end"
+        android:fontFamily="sans-serif-condensed"
+        android:gravity="center"
+        android:maxLines="1"
+        android:textColor="#ffffff"
+        android:textSize="11sp"
+        android:visibility="gone" />
+
+    <GridView
+        android:id="@+id/checkmarkGridWidgetView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="8dp"
+        android:layout_weight="1"
+        android:columnWidth="120dp"
+        android:gravity="center"
+        android:horizontalSpacing="8dp"
+        android:numColumns="auto_fit"
+        android:scrollbars="none"
+        android:stretchMode="columnWidth"
+        android:verticalSpacing="8dp" />
+
+    <TextView
+        android:id="@+id/checkmarkGridWidgetEmptyView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:text="@string/checkmark_stack_widget"
+        android:textColor="#ffffff"
+        android:textStyle="bold"
+        android:textSize="16sp" />
+
+</LinearLayout>

--- a/uhabits-android/src/main/res/layout/widget_checkmark.xml
+++ b/uhabits-android/src/main/res/layout/widget_checkmark.xml
@@ -21,40 +21,86 @@
 <LinearLayout
     android:id="@+id/frame"
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:habit="http://isoron.org/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:habit="http://isoron.org/android"
-    android:gravity="center"
+    android:gravity="center_horizontal"
     android:orientation="vertical">
 
-    <org.isoron.uhabits.activities.common.views.RingView
-        android:id="@+id/scoreRing"
+    <FrameLayout
+        android:id="@+id/ringContainer"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="0.9"
-        habit:thickness="2"
-        habit:textSize="16"
-        habit:enableFontAwesome="true"
+        android:layout_weight="1"
         android:layout_marginTop="8dp"
         android:layout_marginLeft="4dp"
-        android:layout_marginRight="4dp"/>
+        android:layout_marginRight="4dp">
+
+        <org.isoron.uhabits.activities.common.views.RingView
+            android:id="@+id/scoreRing"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            habit:thickness="2"
+            habit:textSize="16"
+            habit:enableFontAwesome="true" />
+
+        <TextView
+            android:id="@+id/streakBadge"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="top|end"
+            android:layout_marginTop="6dp"
+            android:layout_marginRight="6dp"
+            android:paddingLeft="6dp"
+            android:paddingTop="2dp"
+            android:paddingRight="6dp"
+            android:paddingBottom="2dp"
+            android:ellipsize="end"
+            android:fontFamily="sans-serif-condensed"
+            android:maxLines="1"
+            android:textSize="10sp"
+            android:textStyle="bold" />
+
+    </FrameLayout>
+
+    <org.isoron.uhabits.widgets.views.WeeklyHeatmapView
+        android:id="@+id/weeklyHeatmap"
+        android:layout_width="match_parent"
+        android:layout_height="14dp"
+        android:layout_marginLeft="12dp"
+        android:layout_marginTop="2dp"
+        android:layout_marginRight="12dp"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/reminderLabel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="10dp"
+        android:layout_marginTop="2dp"
+        android:layout_marginRight="10dp"
+        android:ellipsize="end"
+        android:fontFamily="sans-serif-condensed"
+        android:gravity="center"
+        android:maxLines="1"
+        android:textSize="10sp"
+        android:visibility="gone" />
 
     <TextView
         android:id="@+id/label"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="0.1"
-        android:textSize="12sp"
-        android:textColor="@color/white"
         android:layout_marginLeft="6dp"
-        android:layout_marginRight="6dp"
-        android:gravity="center"
-        android:scrollHorizontally="true"
-        android:ellipsize="end"
-        android:maxLines="2"
         android:layout_marginTop="4dp"
+        android:layout_marginRight="6dp"
         android:layout_marginBottom="4dp"
+        android:breakStrategy="balanced"
+        android:ellipsize="end"
         android:fontFamily="sans-serif-condensed"
-        android:breakStrategy="balanced" />
+        android:gravity="center"
+        android:maxLines="2"
+        android:scrollHorizontally="true"
+        android:textColor="@color/white"
+        android:textSize="12sp" />
 
 </LinearLayout>

--- a/uhabits-android/src/main/res/layout/widget_graph.xml
+++ b/uhabits-android/src/main/res/layout/widget_graph.xml
@@ -38,14 +38,66 @@
         android:paddingBottom="8dp"
         tools:ignore="UselessParent">
 
-        <TextView
-            android:id="@+id/title"
+        <FrameLayout
+            android:id="@+id/titleRow"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="2dp">
+
+            <TextView
+                android:id="@+id/title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:textSize="@dimen/smallTextSize"
+                android:maxLines="2"
+                android:textColor="@color/white"/>
+
+            <TextView
+                android:id="@+id/streakBadge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end|center_vertical"
+                android:paddingLeft="6dp"
+                android:paddingTop="2dp"
+                android:paddingRight="6dp"
+                android:paddingBottom="2dp"
+                android:ellipsize="end"
+                android:fontFamily="sans-serif-condensed"
+                android:maxLines="1"
+                android:textSize="10sp"
+                android:textStyle="bold" />
+
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/dataContainer"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+        <org.isoron.uhabits.widgets.views.WeeklyHeatmapView
+            android:id="@+id/weeklyHeatmap"
+            android:layout_width="match_parent"
+            android:layout_height="14dp"
+            android:layout_marginLeft="6dp"
+            android:layout_marginTop="4dp"
+            android:layout_marginRight="6dp"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/reminderLabel"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="6dp"
+            android:layout_marginTop="2dp"
+            android:layout_marginRight="6dp"
+            android:ellipsize="end"
+            android:fontFamily="sans-serif-condensed"
             android:gravity="center"
-            android:textSize="@dimen/smallTextSize"
-            android:maxLines="2"
-            android:textColor="@color/white"/>
+            android:maxLines="1"
+            android:textSize="10sp"
+            android:visibility="gone" />
 
     </LinearLayout>
 

--- a/uhabits-android/src/main/res/values/strings.xml
+++ b/uhabits-android/src/main/res/values/strings.xml
@@ -201,6 +201,8 @@
     <string name="database">Database</string>
     <string name="widget_opacity_title">Widget opacity</string>
     <string name="widget_opacity_description">Makes widgets more transparent or more opaque in your home screen.</string>
+    <string name="widget_next_reminder_at">Next reminder at %1$s</string>
+    <string name="widget_dashboard_done_summary">%1$d/%2$d done</string>
     <string name="first_day_of_the_week">First day of the week</string>
     <string name="default_reminder_question">Have you completed this habit today?</string>
     <string name="notes">Notes</string>

--- a/uhabits-android/src/test/java/org/isoron/uhabits/widgets/WidgetHabitStatsTest.kt
+++ b/uhabits-android/src/test/java/org/isoron/uhabits/widgets/WidgetHabitStatsTest.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2016-2025 Álinson Santos Xavier <git@axavier.org>
+ *
+ * This file is part of Loop Habit Tracker.
+ *
+ * Loop Habit Tracker is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * Loop Habit Tracker is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.isoron.uhabits.widgets
+
+import org.isoron.uhabits.core.models.Entry
+import org.isoron.uhabits.core.models.Reminder
+import org.isoron.uhabits.core.models.Timestamp
+import org.isoron.uhabits.core.models.WeekdayList
+import org.isoron.uhabits.core.models.memory.MemoryModelFactory
+import org.isoron.uhabits.core.utils.DateUtils
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.Calendar
+import java.util.GregorianCalendar
+import java.util.TimeZone
+
+class WidgetHabitStatsTest {
+
+    private val gmt = TimeZone.getTimeZone("GMT")
+
+    @Before
+    fun setUp() {
+        DateUtils.setFixedTimeZone(gmt)
+        DateUtils.setFixedLocalTime(null)
+        DateUtils.setStartDayOffset(0, 0)
+    }
+
+    @After
+    fun tearDown() {
+        DateUtils.setFixedTimeZone(null)
+        DateUtils.setFixedLocalTime(null)
+        DateUtils.setStartDayOffset(0, 0)
+    }
+
+    @Test
+    fun computeCurrentStreakDays_usesYesterdayWhenTodayIsUnknown() {
+        val habit = MemoryModelFactory().buildHabit()
+        val today = ts(2026, Calendar.FEBRUARY, 7)
+
+        habit.computedEntries.add(Entry(today.minus(1), Entry.YES_MANUAL))
+        habit.computedEntries.add(Entry(today.minus(2), Entry.YES_MANUAL))
+
+        assertEquals(2, WidgetHabitStats.computeCurrentStreakDays(habit, today))
+    }
+
+    @Test
+    fun computeCurrentStreakDays_isZeroWhenTodayIsExplicitlyNo() {
+        val habit = MemoryModelFactory().buildHabit()
+        val today = ts(2026, Calendar.FEBRUARY, 7)
+
+        habit.computedEntries.add(Entry(today, Entry.NO))
+        habit.computedEntries.add(Entry(today.minus(1), Entry.YES_MANUAL))
+        habit.computedEntries.add(Entry(today.minus(2), Entry.YES_MANUAL))
+
+        assertEquals(0, WidgetHabitStats.computeCurrentStreakDays(habit, today))
+    }
+
+    @Test
+    fun computeWeeklySuccess_returnsOldestToNewest() {
+        val habit = MemoryModelFactory().buildHabit()
+        val today = ts(2026, Calendar.FEBRUARY, 7)
+
+        habit.computedEntries.add(Entry(today.minus(2), Entry.YES_MANUAL))
+        habit.computedEntries.add(Entry(today, Entry.YES_MANUAL))
+
+        val expected = booleanArrayOf(false, false, false, false, true, false, true)
+        assertArrayEquals(expected, WidgetHabitStats.computeWeeklySuccess(habit, today))
+    }
+
+    @Test
+    fun computeNextReminderTimeUtcMillis_respectsWeekdays() {
+        val habit = MemoryModelFactory().buildHabit()
+        habit.reminder = Reminder(19, 30, WeekdayList(4)) // Monday only
+
+        val now = utcMillis(2026, Calendar.FEBRUARY, 7, 18, 0) // Saturday
+        val expected = utcMillis(2026, Calendar.FEBRUARY, 9, 19, 30) // Monday
+
+        assertEquals(expected, WidgetHabitStats.computeNextReminderTimeUtcMillis(habit, now))
+    }
+
+    @Test
+    fun computeNextReminderTimeUtcMillis_usesTomorrowWhenTimeAlreadyPassed() {
+        val habit = MemoryModelFactory().buildHabit()
+        habit.reminder = Reminder(19, 30, WeekdayList.EVERY_DAY)
+
+        val now = utcMillis(2026, Calendar.FEBRUARY, 7, 20, 0)
+        val expected = utcMillis(2026, Calendar.FEBRUARY, 8, 19, 30)
+
+        assertEquals(expected, WidgetHabitStats.computeNextReminderTimeUtcMillis(habit, now))
+    }
+
+    @Test
+    fun computeNextReminderTimeUtcMillis_appliesStartOfDayOffsetForWeekdays() {
+        DateUtils.setStartDayOffset(4, 0)
+
+        val habit = MemoryModelFactory().buildHabit()
+        habit.reminder = Reminder(2, 0, WeekdayList(4)) // Monday only
+
+        val now = utcMillis(2026, Calendar.FEBRUARY, 9, 0, 30) // Monday
+        val expected = utcMillis(2026, Calendar.FEBRUARY, 10, 2, 0) // Tuesday 02:00 counts as Monday
+
+        assertEquals(expected, WidgetHabitStats.computeNextReminderTimeUtcMillis(habit, now))
+    }
+
+    private fun ts(year: Int, javaMonth: Int, day: Int): Timestamp {
+        val cal = GregorianCalendar(gmt)
+        cal.set(year, javaMonth, day, 0, 0, 0)
+        cal.set(Calendar.MILLISECOND, 0)
+        return Timestamp(cal.timeInMillis)
+    }
+
+    private fun utcMillis(year: Int, javaMonth: Int, day: Int, hour: Int, minute: Int): Long {
+        val cal = GregorianCalendar(gmt)
+        cal.set(year, javaMonth, day, hour, minute, 0)
+        cal.set(Calendar.MILLISECOND, 0)
+        return cal.timeInMillis
+    }
+}

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/utils/DateUtils.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/utils/DateUtils.kt
@@ -198,6 +198,7 @@ abstract class DateUtils {
 
             return freq
         }
+
         @JvmStatic
         fun getMonthsSince1970(today: GregorianCalendar): Int {
             val start = GregorianCalendar(TimeZone.getTimeZone("GMT"))


### PR DESCRIPTION

```md
### Summary
Improve home screen widgets by showing quick progress info:
- Current streak badge
- 7-day weekly heatmap
- Next reminder time (when available)

Related: n/a (no issue filed)

### What change does this PR introduce?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

### What is the proposed approach?
- Add a shared helper (`WidgetHabitStats`) to compute:
  - current streak
  - last 7 days completion
  - next reminder time (respects reminder weekdays + start-of-day offset)
- Render the extras on:
  - Checkmark widget
  - Graph widgets (Score/History/Frequency/Streak/Target)
- For large Checkmark stack widgets (3+ habits + big size), switch to a grid dashboard:
  - “X/Y done” summary
  - earliest next reminder across selected habits

### Testing
- `./gradlew ktlintCheck`
- `./gradlew :uhabits-android:testDebugUnitTest`
- `./gradlew :uhabits-android:assembleDebug`
- Manual: installed debug APK on device and verified widget UI changes + resizing (including grid mode)

### Checklist
- [x] The commit message follows our adopted guidelines
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [ ] Relevant comments/docs have been added/updated (for bug fixes/features)
```