### PR TITLE
Overlay multiple habit scores on single chart widget

### DIFF
--- a/uhabits-android/src/main/AndroidManifest.xml
+++ b/uhabits-android/src/main/AndroidManifest.xml
@@ -113,6 +113,15 @@
         </activity>
 
         <activity
+            android:name=".widgets.activities.ScoreHabitPickerDialog"
+            android:exported="true"
+            android:theme="@style/Theme.AppCompat.Light.Dialog">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:name=".activities.about.AboutActivity"
             android:label="@string/about">
             <meta-data

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/ScoreChart.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/common/views/ScoreChart.kt
@@ -45,6 +45,8 @@ import java.util.Random
 import kotlin.math.max
 import kotlin.math.min
 
+data class ScoreSeries(val scores: List<Score>, val color: Int)
+
 class ScoreChart : ScrollableChart {
     private var pGrid: Paint? = null
     private var em = 0f
@@ -62,7 +64,7 @@ class ScoreChart : ScrollableChart {
     private var nColumns = 0
     private var textColor = 0
     private var gridColor = 0
-    private var scores: List<Score>? = null
+    private var seriesList: List<ScoreSeries> = emptyList()
     private var primaryColor = 0
 
     @Deprecated("")
@@ -95,7 +97,7 @@ class ScoreChart : ScrollableChart {
             newScores.add(Score(timestamp.minus(i), current))
             previous = current
         }
-        scores = newScores
+        seriesList = listOf(ScoreSeries(newScores, primaryColor))
     }
 
     fun setBucketSize(bucketSize: Int) {
@@ -110,11 +112,19 @@ class ScoreChart : ScrollableChart {
 
     fun setColor(primaryColor: Int) {
         this.primaryColor = primaryColor
+        if (seriesList.size == 1) {
+            seriesList = listOf(ScoreSeries(seriesList[0].scores, primaryColor))
+        }
         postInvalidate()
     }
 
     fun setScores(scores: List<Score>) {
-        this.scores = scores
+        seriesList = listOf(ScoreSeries(scores, primaryColor))
+        postInvalidate()
+    }
+
+    fun setSeriesList(series: List<ScoreSeries>) {
+        seriesList = series
         postInvalidate()
     }
 
@@ -128,39 +138,78 @@ class ScoreChart : ScrollableChart {
         } else {
             activeCanvas = canvas
         }
-        if (scores == null) return
+        if (seriesList.isEmpty()) return
+
+        // Find the longest series for grid/footer sizing
+        val longestSeries = seriesList.maxByOrNull { it.scores.size } ?: return
+
         rect!![0f, 0f, nColumns * columnWidth] = columnHeight.toFloat()
         rect!!.offset(0f, internalPaddingTop.toFloat())
         drawGrid(activeCanvas, rect)
+
+        // Collect line segments and markers for all series, then draw lines first, markers second.
+        // This prevents XFERMODE_CLEAR in drawMarker from erasing other series' lines.
+        data class LineSegment(val fromX: Float, val fromY: Float, val toX: Float, val toY: Float, val color: Int)
+        data class Marker(val cx: Float, val cy: Float, val color: Int)
+
+        val lines = mutableListOf<LineSegment>()
+        val markers = mutableListOf<Marker>()
+
+        for (series in seriesList) {
+            val scores = series.scores
+            var prevCx = 0f
+            var prevCy = 0f
+            var hasPrev = false
+
+            for (k in 0 until nColumns) {
+                val offset = nColumns - k - 1 + dataOffset
+                if (offset >= scores.size) {
+                    hasPrev = false
+                    continue
+                }
+                val score = scores[offset].value
+                val height = (columnHeight * score).toInt()
+                val cx = k * columnWidth + columnWidth / 2
+                val cy = (internalPaddingTop + columnHeight - height).toFloat()
+
+                if (hasPrev) {
+                    lines.add(LineSegment(prevCx, prevCy, cx, cy, series.color))
+                    markers.add(Marker(prevCx, prevCy, series.color))
+                }
+                if (k == nColumns - 1) {
+                    markers.add(Marker(cx, cy, series.color))
+                }
+                prevCx = cx
+                prevCy = cy
+                hasPrev = true
+            }
+        }
+
+        // Draw all lines first
+        for (line in lines) {
+            pGraph!!.color = line.color
+            activeCanvas!!.drawLine(line.fromX, line.fromY, line.toX, line.toY, pGraph!!)
+        }
+
+        // Then draw all markers
+        for (marker in markers) {
+            drawMarker(activeCanvas, marker.cx, marker.cy, marker.color)
+        }
+
+        // Draw footer using longest series for timestamps
         pText!!.color = textColor
-        pGraph!!.color = primaryColor
-        prevRect!!.setEmpty()
         previousMonthText = ""
         previousYearText = ""
         skipYear = 0
         for (k in 0 until nColumns) {
             val offset = nColumns - k - 1 + dataOffset
-            if (offset >= scores!!.size) continue
-            val score = scores!![offset].value
-            val timestamp = scores!![offset].timestamp
-            val height = (columnHeight * score).toInt()
-            rect!![0f, 0f, baseSize.toFloat()] = baseSize.toFloat()
-            rect!!.offset(
-                k * columnWidth + (columnWidth - baseSize) / 2,
-                (
-                    internalPaddingTop + columnHeight - height - baseSize / 2
-                    ).toFloat()
-            )
-            if (!prevRect!!.isEmpty) {
-                drawLine(activeCanvas, prevRect, rect)
-                drawMarker(activeCanvas, prevRect)
-            }
-            if (k == nColumns - 1) drawMarker(activeCanvas, rect)
-            prevRect!!.set(rect!!)
+            if (offset >= longestSeries.scores.size) continue
+            val timestamp = longestSeries.scores[offset].timestamp
             rect!![0f, 0f, columnWidth] = columnHeight.toFloat()
             rect!!.offset(k * columnWidth, internalPaddingTop.toFloat())
             drawFooter(activeCanvas, rect, timestamp)
         }
+
         if (activeCanvas !== canvas) canvas.drawBitmap(internalDrawingCache!!, 0f, 0f, null)
     }
 
@@ -267,28 +316,19 @@ class ScoreChart : ScrollableChart {
         canvas!!.drawLine(rGrid.left, rGrid.top, rGrid.right, rGrid.top, pGrid!!)
     }
 
-    private fun drawLine(canvas: Canvas?, rectFrom: RectF?, rectTo: RectF?) {
-        pGraph!!.color = primaryColor
-        canvas!!.drawLine(
-            rectFrom!!.centerX(),
-            rectFrom.centerY(),
-            rectTo!!.centerX(),
-            rectTo.centerY(),
-            pGraph!!
+    private fun drawMarker(canvas: Canvas?, cx: Float, cy: Float, color: Int) {
+        val markerRect = RectF(
+            cx - baseSize / 2f,
+            cy - baseSize / 2f,
+            cx + baseSize / 2f,
+            cy + baseSize / 2f
         )
-    }
-
-    private fun drawMarker(canvas: Canvas?, rect: RectF?) {
-        rect!!.inset(baseSize * 0.225f, baseSize * 0.225f)
+        markerRect.inset(baseSize * 0.225f, baseSize * 0.225f)
         setModeOrColor(pGraph, XFERMODE_CLEAR, internalBackgroundColor)
-        canvas!!.drawOval(rect, pGraph!!)
-        rect.inset(baseSize * 0.1f, baseSize * 0.1f)
-        setModeOrColor(pGraph, XFERMODE_SRC, primaryColor)
-        canvas.drawOval(rect, pGraph!!)
-
-//        rect.inset(baseSize * 0.1f, baseSize * 0.1f);
-//        setModeOrColor(pGraph, XFERMODE_CLEAR, backgroundColor);
-//        canvas.drawOval(rect, pGraph);
+        canvas!!.drawOval(markerRect, pGraph!!)
+        markerRect.inset(baseSize * 0.1f, baseSize * 0.1f)
+        setModeOrColor(pGraph, XFERMODE_SRC, color)
+        canvas.drawOval(markerRect, pGraph!!)
         if (isTransparencyEnabled) pGraph!!.xfermode = XFERMODE_SRC
     }
 
@@ -367,7 +407,12 @@ class ScoreChart : ScrollableChart {
     }
 
     private fun setModeOrColor(p: Paint?, mode: PorterDuffXfermode, color: Int) {
-        if (isTransparencyEnabled) p!!.xfermode = mode else p!!.color = color
+        if (isTransparencyEnabled) {
+            p!!.xfermode = mode
+            p.color = color
+        } else {
+            p!!.color = color
+        }
     }
 
     companion object {

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/BaseWidgetProvider.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/BaseWidgetProvider.kt
@@ -70,6 +70,7 @@ abstract class BaseWidgetProvider : AppWidgetProvider() {
     ) {
         try {
             updateDependencies(context)
+            if (widgetPrefs.getHabitIdsFromWidgetId(widgetId).isEmpty()) return
             context.setTheme(R.style.WidgetTheme)
             val widget = getWidgetFromId(context, widgetId)
             val dims = getDimensionsFromOptions(context, options)
@@ -146,6 +147,7 @@ abstract class BaseWidgetProvider : AppWidgetProvider() {
         widgetId: Int
     ) {
         try {
+            if (widgetPrefs.getHabitIdsFromWidgetId(widgetId).isEmpty()) return
             val widget = getWidgetFromId(context, widgetId)
             val options = manager.getAppWidgetOptions(widgetId)
             widget.setDimensions(getDimensionsFromOptions(context, options))

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/MultiScoreWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/MultiScoreWidget.kt
@@ -21,6 +21,8 @@ package org.isoron.uhabits.widgets
 
 import android.app.PendingIntent
 import android.content.Context
+import android.text.SpannableStringBuilder
+import android.text.style.ForegroundColorSpan
 import android.view.View
 import org.isoron.platform.gui.toInt
 import org.isoron.uhabits.activities.common.views.ScoreChart
@@ -68,13 +70,37 @@ class MultiScoreWidget(
     }
 
     override fun buildView(): View {
-        val title = if (habits.size == 1) {
-            habits[0].name
-        } else {
-            "${habits[0].name} +${habits.size - 1}"
-        }
         return GraphWidgetView(context, ScoreChart(context)).apply {
-            setTitle(title)
+            if (habits.size == 1) {
+                setTitle(habits[0].name)
+            } else {
+                setTitle(buildLegend())
+            }
         }
+    }
+
+    private fun buildLegend(): CharSequence {
+        val theme = WidgetTheme()
+        val builder = SpannableStringBuilder()
+        builder.append("(${habits.size} habits) ")
+        habits.forEachIndexed { index, habit ->
+            if (index > 0) builder.append("  ")
+            val truncatedName = if (habit.name.length > 10) {
+                habit.name.take(10) + "\u2026"
+            } else {
+                habit.name
+            }
+            val entry = "\u25CF $truncatedName"
+            val start = builder.length
+            builder.append(entry)
+            val color = theme.color(habit.color).toInt()
+            builder.setSpan(
+                ForegroundColorSpan(color),
+                start,
+                builder.length,
+                SpannableStringBuilder.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+        }
+        return builder
     }
 }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/MultiScoreWidget.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/MultiScoreWidget.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2016-2025 Álinson Santos Xavier <git@axavier.org>
+ *
+ * This file is part of Loop Habit Tracker.
+ *
+ * Loop Habit Tracker is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * Loop Habit Tracker is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.isoron.uhabits.widgets
+
+import android.app.PendingIntent
+import android.content.Context
+import android.view.View
+import org.isoron.platform.gui.toInt
+import org.isoron.uhabits.activities.common.views.ScoreChart
+import org.isoron.uhabits.activities.common.views.ScoreSeries
+import org.isoron.uhabits.core.models.Habit
+import org.isoron.uhabits.core.ui.screens.habits.show.views.ScoreCardPresenter
+import org.isoron.uhabits.core.ui.views.WidgetTheme
+import org.isoron.uhabits.widgets.views.GraphWidgetView
+
+class MultiScoreWidget(
+    context: Context,
+    id: Int,
+    private val habits: List<Habit>
+) : BaseWidget(context, id, false) {
+    override val defaultHeight: Int = 300
+    override val defaultWidth: Int = 300
+
+    override fun getOnClickPendingIntent(context: Context): PendingIntent =
+        pendingIntentFactory.showHabit(habits[0])
+
+    override fun refreshData(view: View) {
+        val theme = WidgetTheme()
+        val seriesList = habits.map { habit ->
+            val viewModel = ScoreCardPresenter.buildState(
+                habit = habit,
+                firstWeekday = prefs.firstWeekdayInt,
+                spinnerPosition = prefs.scoreCardSpinnerPosition,
+                theme = theme
+            )
+            ScoreSeries(
+                scores = viewModel.scores,
+                color = theme.color(habit.color).toInt()
+            )
+        }
+        val bucketSize = ScoreCardPresenter.BUCKET_SIZES[prefs.scoreCardSpinnerPosition]
+
+        val widgetView = view as GraphWidgetView
+        widgetView.setBackgroundAlpha(preferedBackgroundAlpha)
+        if (preferedBackgroundAlpha >= 255) widgetView.setShadowAlpha(0x4f)
+        (widgetView.dataView as ScoreChart).apply {
+            setIsTransparencyEnabled(true)
+            setBucketSize(bucketSize)
+            setSeriesList(seriesList)
+        }
+    }
+
+    override fun buildView(): View {
+        val title = if (habits.size == 1) {
+            habits[0].name
+        } else {
+            "${habits[0].name} +${habits.size - 1}"
+        }
+        return GraphWidgetView(context, ScoreChart(context)).apply {
+            setTitle(title)
+        }
+    }
+}

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/ScoreWidgetProvider.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/ScoreWidgetProvider.kt
@@ -19,14 +19,16 @@
 package org.isoron.uhabits.widgets
 
 import android.content.Context
+import org.isoron.uhabits.core.models.HabitNotFoundException
 
 class ScoreWidgetProvider : BaseWidgetProvider() {
     override fun getWidgetFromId(context: Context, id: Int): BaseWidget {
         val habits = getHabitsFromWidgetId(id)
+        if (habits.isEmpty()) throw HabitNotFoundException()
         return if (habits.size == 1) {
             ScoreWidget(context, id, habits[0])
         } else {
-            StackWidget(context, id, StackWidgetType.SCORE, habits)
+            MultiScoreWidget(context, id, habits)
         }
     }
 }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/activities/HabitPickerDialog.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/activities/HabitPickerDialog.kt
@@ -44,6 +44,10 @@ class NumericalHabitPickerDialog : HabitPickerDialog() {
     override fun getEmptyMessage() = R.string.no_numerical_habits
 }
 
+class ScoreHabitPickerDialog : HabitPickerDialog() {
+    override fun allowMultiSelect() = true
+}
+
 open class HabitPickerDialog : Activity() {
 
     private var widgetId = 0
@@ -53,6 +57,7 @@ open class HabitPickerDialog : Activity() {
     protected open fun shouldHideNumerical() = false
     protected open fun shouldHideBoolean() = false
     protected open fun getEmptyMessage() = R.string.no_habits
+    protected open fun allowMultiSelect() = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -79,18 +84,42 @@ open class HabitPickerDialog : Activity() {
             return
         }
 
-        setContentView(R.layout.widget_configure_activity)
-        val listView = findViewById<ListView>(R.id.listView)
-        val saveButton = findViewById<Button>(R.id.buttonSave)
+        if (allowMultiSelect()) {
+            setContentView(R.layout.widget_configure_activity_multi)
+            val listView = findViewById<ListView>(R.id.listView)
+            val saveButton = findViewById<Button>(R.id.buttonSave)
 
-        with(listView) {
-            adapter = ArrayAdapter(
-                context,
-                android.R.layout.simple_list_item_1,
+            listView.adapter = ArrayAdapter(
+                this,
+                android.R.layout.simple_list_item_multiple_choice,
                 habitNames
             )
-            setOnItemClickListener { parent, view, position, id ->
-                confirm(mutableListOf(habitIds[position]))
+            listView.choiceMode = ListView.CHOICE_MODE_MULTIPLE
+
+            saveButton.setOnClickListener {
+                val selected = mutableListOf<Long>()
+                for (i in 0 until listView.count) {
+                    if (listView.isItemChecked(i)) {
+                        selected.add(habitIds[i])
+                    }
+                }
+                if (selected.isNotEmpty()) {
+                    confirm(selected)
+                }
+            }
+        } else {
+            setContentView(R.layout.widget_configure_activity)
+            val listView = findViewById<ListView>(R.id.listView)
+
+            with(listView) {
+                adapter = ArrayAdapter(
+                    context,
+                    android.R.layout.simple_list_item_1,
+                    habitNames
+                )
+                setOnItemClickListener { parent, view, position, id ->
+                    confirm(mutableListOf(habitIds[position]))
+                }
             }
         }
     }

--- a/uhabits-android/src/main/java/org/isoron/uhabits/widgets/views/GraphWidgetView.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/widgets/views/GraphWidgetView.kt
@@ -26,7 +26,7 @@ import org.isoron.uhabits.R
 
 class GraphWidgetView(context: Context?, val dataView: View) : HabitWidgetView(context) {
     private lateinit var title: TextView
-    fun setTitle(text: String?) {
+    fun setTitle(text: CharSequence?) {
         title.text = text
     }
 

--- a/uhabits-android/src/main/res/layout/widget_configure_activity_multi.xml
+++ b/uhabits-android/src/main/res/layout/widget_configure_activity_multi.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (C) 2016-2025 Álinson Santos Xavier <git@axavier.org>
   ~
   ~ This file is part of Loop Habit Tracker.
@@ -18,16 +17,22 @@
   ~ with this program. If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-                    android:minHeight="100dp"
-                    android:minWidth="100dp"
-                    android:minResizeWidth="100dp"
-                    android:minResizeHeight="100dp"
-                    android:initialLayout="@layout/widget_graph"
-                    android:previewImage="@drawable/widget_preview_score"
-                    android:resizeMode="vertical|horizontal"
-                    android:updatePeriodMillis="3600000"
-                    android:configure="org.isoron.uhabits.widgets.activities.ScoreHabitPickerDialog"
-                    android:widgetCategory="home_screen">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-</appwidget-provider>
+    <ListView
+        android:id="@+id/listView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:choiceMode="multipleChoice" />
+
+    <Button
+        android:id="@+id/buttonSave"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@android:string/ok" />
+
+</LinearLayout>

--- a/uhabits-android/src/main/res/layout/widget_graph.xml
+++ b/uhabits-android/src/main/res/layout/widget_graph.xml
@@ -45,6 +45,7 @@
             android:gravity="center"
             android:textSize="@dimen/smallTextSize"
             android:maxLines="2"
+            android:ellipsize="end"
             android:textColor="@color/white"/>
 
     </LinearLayout>


### PR DESCRIPTION
## Summary

Implements the feature requested in #2264: when multiple habits are selected for the Score widget, overlay all score lines on the same chart using each habit's distinct color, instead of creating a swipeable stack of individual charts.

### UI Changes
- **Habit picker**: Score widget now shows a multi-select checkbox list with a Save button (other widget types are unchanged)
- **Chart rendering**: Multiple colored lines drawn on the same ScoreChart grid. Lines are drawn before markers to prevent XFERMODE_CLEAR artifacts between series.
- **Widget title**: Shows first habit name + count (e.g. "Exercise +2")

### Technical Changes
- `ScoreChart`: Add `ScoreSeries` data class and `setSeriesList()` method; backward-compatible `setScores()`/`setColor()` wrappers preserved
- `MultiScoreWidget`: New widget class taking `List<Habit>`
- `ScoreWidgetProvider`: Routes multi-habit case to `MultiScoreWidget` instead of `StackWidget`
- `HabitPickerDialog`: Add `allowMultiSelect()` hook; new `ScoreHabitPickerDialog` subclass
- New `widget_configure_activity_multi.xml` layout with checkbox list + Save button
- Updated `widget_score_info.xml` and `AndroidManifest.xml` for the new picker activity

### Notes
- This is AI-assisted (Claude Code)
- Looking for feedback on the UI approach before marking ready for review
- Existing single-habit Score widgets continue to work unchanged

## Test plan
- [ ] Add a Score widget → should show checkbox list with Save button
- [ ] Select 1 habit → renders single-line chart (backward compat)
- [ ] Select 3 habits → renders 3 colored lines on same chart
- [ ] Existing single-habit Score widgets continue to work after upgrade
- [ ] Other widget types (checkmark, history, etc.) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)