### PR TITLE
Habit search filter on Habit homepage

### DIFF
--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsMenu.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsMenu.kt
@@ -26,8 +26,8 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
-import me.tatarka.inject.annotations.Inject
 import androidx.appcompat.widget.SearchView
+import me.tatarka.inject.annotations.Inject
 import org.isoron.uhabits.R
 import org.isoron.uhabits.core.models.HabitList
 import org.isoron.uhabits.core.preferences.Preferences

--- a/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsMenu.kt
+++ b/uhabits-android/src/main/java/org/isoron/uhabits/activities/habits/list/ListHabitsMenu.kt
@@ -20,11 +20,14 @@
 package org.isoron.uhabits.activities.habits.list
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import me.tatarka.inject.annotations.Inject
+import androidx.appcompat.widget.SearchView
 import org.isoron.uhabits.R
 import org.isoron.uhabits.core.models.HabitList
 import org.isoron.uhabits.core.preferences.Preferences
@@ -43,10 +46,32 @@ class ListHabitsMenu(
     val behavior: ListHabitsMenuBehavior
 ) {
     val activity = (context as AppCompatActivity)
+    private val handler = Handler(Looper.getMainLooper())
+    private var searchDebounce: Runnable? = null
 
     fun onCreate(inflater: MenuInflater, menu: Menu) {
         menu.clear()
         inflater.inflate(R.menu.list_habits, menu)
+        val searchView = menu.findItem(R.id.actionSearch).actionView as SearchView
+        searchView.queryHint = activity.getString(R.string.search)
+        if (behavior.searchQuery.isNotEmpty()) {
+            searchView.isIconified = false
+            searchView.setQuery(behavior.searchQuery, false)
+        }
+        searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
+            override fun onQueryTextSubmit(query: String) = false
+            override fun onQueryTextChange(newText: String): Boolean {
+                searchDebounce?.let { handler.removeCallbacks(it) }
+                searchDebounce = Runnable { behavior.onSearchQueryChanged(newText) }
+                handler.postDelayed(searchDebounce!!, SEARCH_DEBOUNCE_MS)
+                return true
+            }
+        })
+        searchView.setOnCloseListener {
+            searchDebounce?.let { handler.removeCallbacks(it) }
+            behavior.onSearchQueryChanged("")
+            false
+        }
         val nightModeItem = menu.findItem(R.id.actionToggleNightMode)
         val hideArchivedItem = menu.findItem(R.id.actionHideArchived)
         val hideCompletedItem = menu.findItem(R.id.actionHideCompleted)
@@ -81,6 +106,10 @@ class ListHabitsMenu(
             HabitList.Order.BY_STATUS_DESC -> sortStatus.icon = arrowUp
             HabitList.Order.BY_POSITION -> sortManual.icon = arrowUp
         }
+    }
+
+    companion object {
+        private const val SEARCH_DEBOUNCE_MS = 150L
     }
 
     fun onItemSelected(item: MenuItem): Boolean {

--- a/uhabits-android/src/main/res/menu/list_habits.xml
+++ b/uhabits-android/src/main/res/menu/list_habits.xml
@@ -23,6 +23,12 @@
     tools:context=".MainActivity">
 
     <item
+        android:id="@+id/actionSearch"
+        android:title="@string/search"
+        app:showAsAction="always"
+        app:actionViewClass="androidx.appcompat.widget.SearchView"/>
+
+    <item
         android:id="@+id/actionCreateHabit"
         android:enabled="true"
         android:icon="?iconAdd"

--- a/uhabits-android/src/main/res/values/strings.xml
+++ b/uhabits-android/src/main/res/values/strings.xml
@@ -162,6 +162,7 @@
     <string name="reminder_sound">Reminder sound</string>
     <string name="none">None</string>
     <string name="filter">Filter</string>
+    <string name="search">Search</string>
     <string name="hide_completed">Hide completed</string>
     <string name="hide_entered">Hide entered</string>
     <string name="hide_archived">Hide archived</string>

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/HabitMatcher.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/models/HabitMatcher.kt
@@ -22,13 +22,24 @@ data class HabitMatcher(
     val isArchivedAllowed: Boolean = false,
     val isReminderRequired: Boolean = false,
     val isCompletedAllowed: Boolean = true,
-    val isEnteredAllowed: Boolean = true
+    val isEnteredAllowed: Boolean = true,
+    val searchQuery: String = ""
 ) {
     fun matches(habit: Habit): Boolean {
         if (!isArchivedAllowed && habit.isArchived) return false
         if (isReminderRequired && !habit.hasReminder()) return false
         if (!isCompletedAllowed && habit.isCompletedToday()) return false
         if (!isEnteredAllowed && habit.isEnteredToday()) return false
+        if (searchQuery.isNotEmpty()) {
+            val q = searchQuery.trim()
+            if (q.isNotEmpty() &&
+                !habit.name.contains(q, ignoreCase = true) &&
+                !habit.question.contains(q, ignoreCase = true) &&
+                !habit.description.contains(q, ignoreCase = true)
+            ) {
+                return false
+            }
+        }
         return true
     }
 

--- a/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsMenuBehavior.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsMenuBehavior.kt
@@ -33,6 +33,8 @@ class ListHabitsMenuBehavior(
 ) {
     private var showCompleted: Boolean
     private var showArchived: Boolean
+    var searchQuery: String = ""
+        private set
 
     fun onCreateHabit() {
         screen.showSelectHabitTypeDialog()
@@ -48,6 +50,11 @@ class ListHabitsMenuBehavior(
 
     fun onViewSettings() {
         screen.showSettingsScreen()
+    }
+
+    fun onSearchQueryChanged(query: String) {
+        searchQuery = query
+        updateAdapterFilter()
     }
 
     fun onToggleShowArchived() {
@@ -107,14 +114,16 @@ class ListHabitsMenuBehavior(
             adapter.setFilter(
                 HabitMatcher(
                     isArchivedAllowed = showArchived,
-                    isEnteredAllowed = showCompleted
+                    isEnteredAllowed = showCompleted,
+                    searchQuery = searchQuery
                 )
             )
         } else {
             adapter.setFilter(
                 HabitMatcher(
                     isArchivedAllowed = showArchived,
-                    isCompletedAllowed = showCompleted
+                    isCompletedAllowed = showCompleted,
+                    searchQuery = searchQuery
                 )
             )
         }

--- a/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/models/HabitMatcherTest.kt
+++ b/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/models/HabitMatcherTest.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2016-2025 Álinson Santos Xavier <git@axavier.org>
+ *
+ * This file is part of Loop Habit Tracker.
+ *
+ * Loop Habit Tracker is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * Loop Habit Tracker is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.isoron.uhabits.core.models
+
+import org.isoron.uhabits.core.BaseUnitTest
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HabitMatcherTest : BaseUnitTest() {
+
+    private fun buildHabit(
+        name: String,
+        question: String = "",
+        description: String = ""
+    ): Habit {
+        val habit = modelFactory.buildHabit()
+        habit.name = name
+        habit.question = question
+        habit.description = description
+        return habit
+    }
+
+    @Test
+    fun testSearchByName() {
+        val habit = buildHabit("Yoga practice")
+        assertTrue(HabitMatcher(searchQuery = "yoga").matches(habit))
+    }
+
+    @Test
+    fun testSearchByQuestion() {
+        val habit = buildHabit("Exercise", question = "Did you do yoga today?")
+        assertTrue(HabitMatcher(searchQuery = "yoga").matches(habit))
+    }
+
+    @Test
+    fun testSearchByNotes() {
+        val habit = buildHabit("Exercise", description = "morning yoga routine")
+        assertTrue(HabitMatcher(searchQuery = "yoga").matches(habit))
+    }
+
+    @Test
+    fun testSearchCaseInsensitive() {
+        val habit = buildHabit("yoga practice")
+        assertTrue(HabitMatcher(searchQuery = "YOGA").matches(habit))
+    }
+
+    @Test
+    fun testSearchNoMatch() {
+        val habit = buildHabit("Running", question = "Did you run?", description = "daily jog")
+        assertFalse(HabitMatcher(searchQuery = "yoga").matches(habit))
+    }
+
+    @Test
+    fun testSearchEmptyQuery() {
+        val habit = buildHabit("Running", description = "daily jog")
+        assertTrue(HabitMatcher(searchQuery = "").matches(habit))
+    }
+
+    // --- Whitespace handling ---
+
+    @Test
+    fun testSearchTrimsLeadingSpaces() {
+        val habit = buildHabit("Yoga practice")
+        assertTrue(HabitMatcher(searchQuery = "  yoga").matches(habit))
+    }
+
+    @Test
+    fun testSearchTrimsTrailingSpaces() {
+        val habit = buildHabit("Yoga practice")
+        assertTrue(HabitMatcher(searchQuery = "yoga  ").matches(habit))
+    }
+
+    @Test
+    fun testSearchWhitespaceOnlyQueryMatchesAll() {
+        val habit = buildHabit("Running")
+        assertTrue(HabitMatcher(searchQuery = "   ").matches(habit))
+    }
+
+    // --- Accented / Unicode characters ---
+
+    @Test
+    fun testSearchAccentedCharacterInName() {
+        val habit = buildHabit("Méditer")
+        assertTrue(HabitMatcher(searchQuery = "méditer").matches(habit))
+    }
+
+    @Test
+    fun testSearchCaseInsensitiveAccented() {
+        val habit = buildHabit("méditer")
+        assertTrue(HabitMatcher(searchQuery = "MÉDITER").matches(habit))
+    }
+
+    @Test
+    fun testSearchUnaccentedQueryDoesNotMatchAccented() {
+        // We do not normalise Unicode: "mediter" ≠ "méditer". Documented expected behaviour.
+        val habit = buildHabit("Méditer")
+        assertFalse(HabitMatcher(searchQuery = "mediter").matches(habit))
+    }
+
+    // --- Emoji, numbers, punctuation ---
+
+    @Test
+    fun testSearchEmojiDoesNotBlockTextMatch() {
+        val habit = buildHabit("🧘 Yoga")
+        assertTrue(HabitMatcher(searchQuery = "yoga").matches(habit))
+    }
+
+    @Test
+    fun testSearchNumbersInName() {
+        val habit = buildHabit("10k Run")
+        assertTrue(HabitMatcher(searchQuery = "10k").matches(habit))
+    }
+
+    // --- Boundary / edge cases ---
+
+    @Test
+    fun testSearchSingleCharacter() {
+        val habit = buildHabit("Yoga")
+        assertTrue(HabitMatcher(searchQuery = "y").matches(habit))
+    }
+
+    @Test
+    fun testSearchQueryLongerThanAllFields() {
+        val habit = buildHabit("Run", question = "Did you run?", description = "jog")
+        assertFalse(HabitMatcher(searchQuery = "a".repeat(100)).matches(habit))
+    }
+
+    @Test
+    fun testSearchEmptyQuestionAndDescription() {
+        // Only name is populated; match and non-match both work without crashing.
+        val habit = buildHabit("Yoga")
+        assertTrue(HabitMatcher(searchQuery = "yoga").matches(habit))
+        assertFalse(HabitMatcher(searchQuery = "running").matches(habit))
+    }
+}

--- a/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsMenuBehaviorTest.kt
+++ b/uhabits-core/src/jvmTest/java/org/isoron/uhabits/core/ui/screens/habits/list/ListHabitsMenuBehaviorTest.kt
@@ -176,4 +176,37 @@ class ListHabitsMenuBehaviorTest : BaseUnitTest() {
         verify(themeSwitcher).toggleNightMode()
         verify(screen).applyTheme()
     }
+
+    @Test
+    fun testOnSearchQueryChanged() {
+        behavior.onSearchQueryChanged("yoga")
+        verify(adapter).setFilter(matcherCaptor.capture())
+        verify(adapter).refresh()
+        assertThat(matcherCaptor.lastValue.searchQuery, equalTo("yoga"))
+    }
+
+    @Test
+    fun testSearchQueryClearedOnEmpty() {
+        behavior.onSearchQueryChanged("")
+        verify(adapter).setFilter(matcherCaptor.capture())
+        assertThat(matcherCaptor.lastValue.searchQuery, equalTo(""))
+    }
+
+    @Test
+    fun testSearchCoexistsWithArchivedFilter() {
+        behavior.onToggleShowArchived()
+        clearInvocations(adapter)
+        behavior.onSearchQueryChanged("yoga")
+        verify(adapter).setFilter(matcherCaptor.capture())
+        assertTrue(matcherCaptor.lastValue.isArchivedAllowed)
+        assertThat(matcherCaptor.lastValue.searchQuery, equalTo("yoga"))
+    }
+
+    @Test
+    fun testSearchQueryExposedForMenuRestore() {
+        behavior.onSearchQueryChanged("yoga")
+        assertThat(behavior.searchQuery, equalTo("yoga"))
+        behavior.onSearchQueryChanged("")
+        assertThat(behavior.searchQuery, equalTo(""))
+    }
 }


### PR DESCRIPTION
I took a stab at implementing the "Habit search" feature mentioned in #676. I saw the contributors guide asks for UI changes to be done in discussion first, but I figured this is quick enough to implement I can give ya'll screenshots of the real deal instead of mockups and see if you like it.

I'm not a super experienced Android dev, so apologies if there is anything obvious I missed.

## Feature

- Adds standard Android search option into toolbar to filter habits quickly by keyword
  - It searches in `Name`, `Question`, and `Notes`; similar to good UX of Bitwarden
- includes debounce for user typing

### Feature: why?

There is plenty of discussion in previous issues on why it's useful, but to add my own reason:
- I have 25+ almost identical habits, only differentiated by a numeric key. Search would make it much less frustrating to fine the one that I need to add a check for.  Habits is the perfect app for tracking them, it's just the volume of them which makes it difficult to manage.
- I find the Bitwarden vault search to be relatively frictionless since it searches across a variety of fields, that was the inspiration for multiple fields here.

## Screenshots

- Main list page with search icon
- Example of searching by title keyword and filtering habits
- Example of searching by the word `627` which is in the hidden Question field for the one habit which is left after filtering
<p float="left">
<img width="200" height="400" alt="Main list page" src="https://github.com/user-attachments/assets/4c3f0d63-bdbf-4937-b15f-bd4b56cf7672" />
<img width="200" height="400" alt="searching by title" src="https://github.com/user-attachments/assets/a7505040-cf93-4075-bcf9-4b23ce853d08" />
<img width="200" height="400" alt="searching in Question field" src="https://github.com/user-attachments/assets/465da644-bb2d-442c-9878-60138c7f70b1" />

</p>

## Testing

- [x] Unit tests added
- [x] Manually tested on a Moto x4 (Android 9) with > 50 habits 
- [?] Instrumented tests: ran into issues on versions 36, 34, and 30


## Open Questions to improve PR

- Translations: are there any files I have missed for this?
- What API version do ya'll usually test on? I was only about to make it run on `30`; `34` and `36` would stall at `Waiting for emulator to boot... `

---

## Instrumented test issues

I attempted to follow the contribution guidelines and run the emulator tests, though I kept running into errors which appeared to be in parts of the codebase unrelated to my changes. I could be missing something, though.

Example: `./build.sh android-tests 30` 
```
* Fetching test screenshots... 
adb: error: failed to stat remote object '/sdcard/Android/data/org.isoron.uhabits/files/test-screenshots': No such file or directory
rm: /sdcard/Android/data/org.isoron.uhabits/files/test-screenshots/: No such file or directory
```

