### PR TITLE
Fix timezone handling for local date display

### DIFF
--- a/uhabits-core/src/jvmMain/java/org/isoron/platform/time/JavaDates.kt
+++ b/uhabits-core/src/jvmMain/java/org/isoron/platform/time/JavaDates.kt
@@ -36,7 +36,7 @@ import java.util.TimeZone
 
 fun LocalDate.toGregorianCalendar(): GregorianCalendar {
     val cal = GregorianCalendar()
-    cal.timeZone = TimeZone.getTimeZone("GMT")
+   cal.timeZone = TimeZone.getDefault()
     cal.set(MILLISECOND, 0)
     cal.set(SECOND, 0)
     cal.set(MINUTE, 0)
@@ -85,7 +85,7 @@ class JavaLocalDateFormatter(private val locale: Locale) : LocalDateFormatter {
 
     fun longFormat(date: LocalDate): String {
         val df = DateFormat.getDateInstance(DateFormat.MEDIUM, locale)
-        df.timeZone = TimeZone.getTimeZone("UTC")
+       df.timeZone = TimeZone.getDefault()
         return df.format(date.toGregorianCalendar().time)
     }
 


### PR DESCRIPTION
This PR replaces hardcoded GMT/UTC timezone handling with the system default timezone to ensure correct local date display for users in different regions.

Issue observed:
The app displayed an older date than the actual current local date.